### PR TITLE
Error display on the login form pages

### DIFF
--- a/revolv/base/tests/tests.py
+++ b/revolv/base/tests/tests.py
@@ -77,7 +77,7 @@ class UserAuthTestCase(TestUserMixin, TestCase):
             "username": "hjksadhfiobhv",
             "password": "njnpvbebijrwehgjsd"
         }, follow=True)
-        self.assertRedirects(response, self.SIGNIN_URL)
+        self.assertTemplateUsed(response, "base/sign_in.html")
         self._assert_no_user_authed(response)
 
     def test_login_logout(self):
@@ -111,7 +111,7 @@ class UserAuthTestCase(TestUserMixin, TestCase):
         no_email_data["email"] = ""
 
         response = self.client.post(self.SIGNUP_URL, no_name_data, follow=True)
-        self.assertRedirects(response, self.SIGNIN_URL)
+        self.assertTemplateUsed(response, "base/sign_in.html")
         self._assert_no_user_authed(response)
 
         response = self.client.post(
@@ -119,7 +119,7 @@ class UserAuthTestCase(TestUserMixin, TestCase):
             no_email_data,
             follow=True
         )
-        self.assertRedirects(response, self.SIGNIN_URL)
+        self.assertTemplateUsed(response, "base/sign_in.html")
         self._assert_no_user_authed(response)
 
         response = self.client.post(self.SIGNUP_URL, valid_data, follow=True)

--- a/revolv/templates/base/sign_in.html
+++ b/revolv/templates/base/sign_in.html
@@ -10,20 +10,26 @@
         <h1>Log in</h1>
         <form action="/login/" method="post" id="login_form">
             {% csrf_token %}
+            {% for error in login_form.non_field_errors %}
+              <small class="error">{{ error }}</small>
+            {% endfor %}
             {% for login_field in login_form %}
                 {% include "base/partials/tooltip_formfield.html" with field=login_field %}
             {% endfor %}
-            <button class="medium" type="submit" value="Log in">Sign In</button>
+            <button class="medium" type="submit" value="Log in">Log in</button>
         </form>
     </div>
     <div class="small-6 columns">
         <h1>Sign Up</h1>
         <form action="/signup/" method="post" id="login_form">
             {% csrf_token %}
+            {% for error in signup_form.non_field_errors %}
+              <small class="error">{{ error }}</small>
+            {% endfor %}
             {% for signup_field in signup_form %}
                 {% include "base/partials/tooltip_formfield.html" with field=signup_field %}
             {% endfor %}
-            <button class="medium" type="submit" value="Log in">Log In</button>
+            <button class="medium" type="submit" value="Log in">Sign up</button>
         </form>
     </div>
 </div>


### PR DESCRIPTION
For #53.

Problem: errors weren't displaying because both the `LoginView` and `SignupView` redirected in the case of errors.

Solution: changed the views to render the template with the form instead. Yeeee

Not really sure if I should be testing that the errors show up, because that's functionality that will work as long as we include the specified HTML...
