### PR TITLE
Reinvestment for categories

### DIFF
--- a/revolv/base/migrations/0007_revolvuserprofile_preferred_categories.py
+++ b/revolv/base/migrations/0007_revolvuserprofile_preferred_categories.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations, models
 
 
 class Migration(migrations.Migration):

--- a/revolv/base/migrations/0007_revolvuserprofile_preferred_categories.py
+++ b/revolv/base/migrations/0007_revolvuserprofile_preferred_categories.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('project', '0037_auto_20150414_0117'),
+        ('base', '0006_remove_revolvuserprofile_repayments'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='revolvuserprofile',
+            name='preferred_categories',
+            field=models.ManyToManyField(to='project.Category'),
+            preserve_default=True,
+        ),
+    ]

--- a/revolv/base/models.py
+++ b/revolv/base/models.py
@@ -70,6 +70,7 @@ class RevolvUserProfile(FacebookModel):
     subscribed_to_newsletter = models.BooleanField(default=False)
 
     reinvest_pool = models.FloatField(default=0.0)
+    preferred_categories = models.ManyToManyField("project.Category")
 
     def is_donor(self):
         """Return whether the associated user can donate."""

--- a/revolv/payments/models.py
+++ b/revolv/payments/models.py
@@ -351,7 +351,7 @@ class PaymentManager(models.Manager):
         :return:
             Returns the total amount reinvested for a specified user or project or both.
         """
-        total_amount = self.reinvestment_fragments(user, project).aggregate(
+        total_amount = self.reinvestment_fragments(user, project, queryset).aggregate(
             models.Sum('amount')
         )['amount__sum']
         if total_amount is None:

--- a/revolv/payments/models.py
+++ b/revolv/payments/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+
 from revolv.base.models import RevolvUserProfile
 from revolv.lib.utils import ImportProxy
 
@@ -339,6 +340,24 @@ class PaymentManager(models.Manager):
             queryset = self.donations()
         num_users = queryset.values("user").distinct().count()
         return num_users
+
+    def total_reinvestment_amount(self, user=None, project=None, queryset=None):
+        """
+        :kwargs:
+            user: filter donations by this user
+            project: filter donations by this project
+            queryset: further filtering of Payments
+
+        :return:
+            Returns the total amount reinvested for a specified user or project or both.
+        """
+        total_amount = self.reinvestment_fragments(user, project).aggregate(
+            models.Sum('amount')
+        )['amount__sum']
+        if total_amount is None:
+            return 0
+        else:
+            return total_amount
 
 
 class Payment(models.Model):

--- a/revolv/payments/signals.py
+++ b/revolv/payments/signals.py
@@ -96,8 +96,9 @@ def post_save_admin_reinvestment(**kwargs):
         if total_left <= 0.0:
             break
 
-    users_without_preferences = RevolvUserProfile.objects.filter(reinvest_pool__gt=0.0).exclude(pk__in=users_with_preferences)
+    # if we still have money we want to reinvest, loop through users without preferences
     if total_left > 0.0:
+        users_without_preferences = RevolvUserProfile.objects.filter(reinvest_pool__gt=0.0).exclude(pk__in=users_with_preferences)
         for user in users_without_preferences:
             total_left -= user.reinvest_pool
             reinvest_amount = user.reinvest_pool + min(0.0, total_left)

--- a/revolv/payments/signals.py
+++ b/revolv/payments/signals.py
@@ -76,7 +76,6 @@ def post_save_admin_reinvestment(**kwargs):
     Category of the project begin invested into. We only consider users that
     have a non-zero pool of investable money.
 
-    !!! TODO: actually prioritize by Category
     """
     if not kwargs.get('created'):
         return

--- a/revolv/payments/tests/models/test_payment.py
+++ b/revolv/payments/tests/models/test_payment.py
@@ -390,13 +390,9 @@ class PaymentTest(TestCase):
 
         self.assertEquals(project2.amount_donated, 200.00)
         self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).count(), 1)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'], 50.00)
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user1, project2), 50.00)
         self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).count(), 1)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'], 150.00)
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user2, project2), 150.00)
         # must reload to get new reinvest_pool amount
         user1 = RevolvUserProfile.objects.get(pk=user1.pk)
         user2 = RevolvUserProfile.objects.get(pk=user2.pk)
@@ -407,13 +403,9 @@ class PaymentTest(TestCase):
 
         self.assertEquals(project2.amount_donated, 0)
         self.assertEquals(Payment.objects.reinvestment_fragments(user1).count(), 0)
-        self.assertIsNone(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'])
-        self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).count(), 0)
-        self.assertIsNone(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'])
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user1), 0)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user2).count(), 0)
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user2), 0)
         # must reload to get new reinvest_pool amount
         user1 = RevolvUserProfile.objects.get(pk=user1.pk)
         user2 = RevolvUserProfile.objects.get(pk=user2.pk)
@@ -465,17 +457,11 @@ class PaymentTest(TestCase):
         # checks that only users with preferences for project 2 actually donate
         self.assertEquals(project2.amount_donated, 250.00)
         self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).count(), 1)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'], 50.00)
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user1, project2), 50.00)
         self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).count(), 0)
-        self.assertIsNone(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'])
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user2, project2), 0)
         self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).count(), 1)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'], 200.00)
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user3, project2), 200.00)
         # must reload to get new reinvest_pool amount
         user1 = RevolvUserProfile.objects.get(pk=user1.pk)
         user2 = RevolvUserProfile.objects.get(pk=user2.pk)
@@ -489,17 +475,12 @@ class PaymentTest(TestCase):
         # checks that after deleting, we have no reinvestment fragments
         self.assertEquals(project2.amount_donated, 0)
         self.assertEquals(Payment.objects.reinvestment_fragments(user1).count(), 0)
-        self.assertIsNone(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'])
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user1), 0)
         self.assertEquals(Payment.objects.reinvestment_fragments(user2).count(), 0)
-        self.assertIsNone(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'])
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user2), 0)
         self.assertEquals(Payment.objects.reinvestment_fragments(user3).count(), 0)
-        self.assertIsNone(Payment.objects.reinvestment_fragments(user3, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'])
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user3), 0)
+
         # must reload to get new reinvest_pool amount
         user1 = RevolvUserProfile.objects.get(pk=user1.pk)
         user2 = RevolvUserProfile.objects.get(pk=user2.pk)
@@ -556,17 +537,11 @@ class PaymentTest(TestCase):
         # has leftover funds
         self.assertEquals(project2.amount_donated, 350.00)
         self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).count(), 1)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'], 50.00)
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user1, project2), 50.00)
         self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).count(), 1)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'], 100.00)
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user2, project2), 100.00)
         self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).count(), 1)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'], 200.00)
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user3, project2), 200.00)
         # must reload to get new reinvest_pool amount
         user1 = RevolvUserProfile.objects.get(pk=user1.pk)
         user2 = RevolvUserProfile.objects.get(pk=user2.pk)
@@ -580,17 +555,12 @@ class PaymentTest(TestCase):
         # checks that after deleting, we have no reinvestment fragments
         self.assertEquals(project2.amount_donated, 0)
         self.assertEquals(Payment.objects.reinvestment_fragments(user1).count(), 0)
-        self.assertIsNone(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'])
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user1), 0)
         self.assertEquals(Payment.objects.reinvestment_fragments(user2).count(), 0)
-        self.assertIsNone(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'])
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user2), 0)
         self.assertEquals(Payment.objects.reinvestment_fragments(user3).count(), 0)
-        self.assertIsNone(Payment.objects.reinvestment_fragments(user3, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'])
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user3), 0)
+
         # must reload to get new reinvest_pool amount
         user1 = RevolvUserProfile.objects.get(pk=user1.pk)
         user2 = RevolvUserProfile.objects.get(pk=user2.pk)
@@ -643,17 +613,12 @@ class PaymentTest(TestCase):
         # checks that all three users donate, and that all of their reinvest pools are depleted
         self.assertEquals(project2.amount_donated, 400.00)
         self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).count(), 1)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'], 50.00)
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user1, project2), 50.00)
         self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).count(), 1)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'], 150.00)
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user2, project2), 150.00)
         self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).count(), 1)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'], 200.00)
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user3, project2), 200.00)
+
         # must reload to get new reinvest_pool amount
         user1 = RevolvUserProfile.objects.get(pk=user1.pk)
         user2 = RevolvUserProfile.objects.get(pk=user2.pk)
@@ -667,17 +632,11 @@ class PaymentTest(TestCase):
         # checks that after deleting, we have no reinvestment fragments
         self.assertEquals(project2.amount_donated, 0)
         self.assertEquals(Payment.objects.reinvestment_fragments(user1).count(), 0)
-        self.assertIsNone(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'])
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user1), 0)
         self.assertEquals(Payment.objects.reinvestment_fragments(user2).count(), 0)
-        self.assertIsNone(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'])
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user2), 0)
         self.assertEquals(Payment.objects.reinvestment_fragments(user3).count(), 0)
-        self.assertIsNone(Payment.objects.reinvestment_fragments(user3, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'])
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user3), 0)
         # must reload to get new reinvest_pool amount
         user1 = RevolvUserProfile.objects.get(pk=user1.pk)
         user2 = RevolvUserProfile.objects.get(pk=user2.pk)
@@ -732,17 +691,11 @@ class PaymentTest(TestCase):
         # checks that user 1 and user 3 donate
         self.assertEquals(project2.amount_donated, 250.00)
         self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).count(), 1)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'], 50.00)
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user1, project2), 50.00)
         self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).count(), 0)
-        self.assertIsNone(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'])
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user2, project2), 0)
         self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).count(), 1)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'], 200.00)
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user3, project2), 200.00)
         # must reload to get new reinvest_pool amount
         user1 = RevolvUserProfile.objects.get(pk=user1.pk)
         user2 = RevolvUserProfile.objects.get(pk=user2.pk)
@@ -757,17 +710,11 @@ class PaymentTest(TestCase):
         # checks that user 1 and user 3 donate
         self.assertEquals(project3.amount_donated, 150.00)
         self.assertEquals(Payment.objects.reinvestment_fragments(user1, project3).count(), 0)
-        self.assertIsNone(Payment.objects.reinvestment_fragments(user1, project3).aggregate(
-            Sum('amount')
-        )['amount__sum'])
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user1, project3), 0)
         self.assertEquals(Payment.objects.reinvestment_fragments(user2, project3).count(), 1)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user2, project3).aggregate(
-            Sum('amount')
-        )['amount__sum'], 150.00)
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user2, project3), 150.00)
         self.assertEquals(Payment.objects.reinvestment_fragments(user3, project3).count(), 0)
-        self.assertIsNone(Payment.objects.reinvestment_fragments(user3, project3).aggregate(
-            Sum('amount')
-        )['amount__sum'])
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user3, project3), 0)
         # must reload to get new reinvest_pool amount
         user1 = RevolvUserProfile.objects.get(pk=user1.pk)
         user2 = RevolvUserProfile.objects.get(pk=user2.pk)
@@ -782,17 +729,12 @@ class PaymentTest(TestCase):
         # checks that after deleting, we have no reinvestment fragments
         self.assertEquals(project2.amount_donated, 0)
         self.assertEquals(Payment.objects.reinvestment_fragments(user1).count(), 0)
-        self.assertIsNone(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'])
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user1), 0)
         self.assertEquals(Payment.objects.reinvestment_fragments(user2).count(), 0)
-        self.assertIsNone(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'])
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user2), 0)
         self.assertEquals(Payment.objects.reinvestment_fragments(user3).count(), 0)
-        self.assertIsNone(Payment.objects.reinvestment_fragments(user3, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'])
+        self.assertEquals(Payment.objects.total_reinvestment_amount(user3), 0)
+
         # must reload to get new reinvest_pool amount
         user1 = RevolvUserProfile.objects.get(pk=user1.pk)
         user2 = RevolvUserProfile.objects.get(pk=user2.pk)

--- a/revolv/payments/tests/models/test_payment.py
+++ b/revolv/payments/tests/models/test_payment.py
@@ -389,7 +389,7 @@ class PaymentTest(TestCase):
         reinvest1.save()
 
         self.assertEquals(project2.amount_donated, 200.00)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user1).count(), 1)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).count(), 1)
         self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
             Sum('amount')
         )['amount__sum'], 50.00)
@@ -464,18 +464,18 @@ class PaymentTest(TestCase):
 
         # checks that only users with preferences for project 2 actually donate
         self.assertEquals(project2.amount_donated, 250.00)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user1).count(), 1)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).count(), 1)
         self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
             Sum('amount')
         )['amount__sum'], 50.00)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).count(), 1)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'], 200.00)
         self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).count(), 0)
         self.assertIsNone(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
             Sum('amount')
         )['amount__sum'])
+        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).count(), 1)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).aggregate(
+            Sum('amount')
+        )['amount__sum'], 200.00)
         # must reload to get new reinvest_pool amount
         user1 = RevolvUserProfile.objects.get(pk=user1.pk)
         user2 = RevolvUserProfile.objects.get(pk=user2.pk)
@@ -492,7 +492,7 @@ class PaymentTest(TestCase):
         self.assertIsNone(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
             Sum('amount')
         )['amount__sum'])
-        self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).count(), 0)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user2).count(), 0)
         self.assertIsNone(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
             Sum('amount')
         )['amount__sum'])
@@ -555,18 +555,18 @@ class PaymentTest(TestCase):
         # checks that all three users donate, and user 2, the user with no preferences,
         # has leftover funds
         self.assertEquals(project2.amount_donated, 350.00)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user1).count(), 1)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).count(), 1)
         self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
             Sum('amount')
         )['amount__sum'], 50.00)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).count(), 1)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'], 200.00)
         self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).count(), 1)
         self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
             Sum('amount')
         )['amount__sum'], 100.00)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).count(), 1)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).aggregate(
+            Sum('amount')
+        )['amount__sum'], 200.00)
         # must reload to get new reinvest_pool amount
         user1 = RevolvUserProfile.objects.get(pk=user1.pk)
         user2 = RevolvUserProfile.objects.get(pk=user2.pk)
@@ -583,7 +583,7 @@ class PaymentTest(TestCase):
         self.assertIsNone(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
             Sum('amount')
         )['amount__sum'])
-        self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).count(), 0)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user2).count(), 0)
         self.assertIsNone(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
             Sum('amount')
         )['amount__sum'])
@@ -642,18 +642,18 @@ class PaymentTest(TestCase):
 
         # checks that all three users donate, and that all of their reinvest pools are depleted
         self.assertEquals(project2.amount_donated, 400.00)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user1).count(), 1)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).count(), 1)
         self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
             Sum('amount')
         )['amount__sum'], 50.00)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).count(), 1)
-        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).aggregate(
-            Sum('amount')
-        )['amount__sum'], 200.00)
         self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).count(), 1)
         self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
             Sum('amount')
         )['amount__sum'], 150.00)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).count(), 1)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).aggregate(
+            Sum('amount')
+        )['amount__sum'], 200.00)
         # must reload to get new reinvest_pool amount
         user1 = RevolvUserProfile.objects.get(pk=user1.pk)
         user2 = RevolvUserProfile.objects.get(pk=user2.pk)
@@ -670,7 +670,122 @@ class PaymentTest(TestCase):
         self.assertIsNone(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
             Sum('amount')
         )['amount__sum'])
+        self.assertEquals(Payment.objects.reinvestment_fragments(user2).count(), 0)
+        self.assertIsNone(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
+            Sum('amount')
+        )['amount__sum'])
+        self.assertEquals(Payment.objects.reinvestment_fragments(user3).count(), 0)
+        self.assertIsNone(Payment.objects.reinvestment_fragments(user3, project2).aggregate(
+            Sum('amount')
+        )['amount__sum'])
+        # must reload to get new reinvest_pool amount
+        user1 = RevolvUserProfile.objects.get(pk=user1.pk)
+        user2 = RevolvUserProfile.objects.get(pk=user2.pk)
+        user3 = RevolvUserProfile.objects.get(pk=user3.pk)
+        self.assertEquals(user1.reinvest_pool, 50.00)
+        self.assertEquals(user2.reinvest_pool, 150.00)
+        self.assertEquals(user3.reinvest_pool, 200.00)
+
+    def test_admin_multiple_reinvestments(self):
+        """
+        Test reinvestment on AdminReinvestment level. Lots of moving parts,
+        see docstrings for respective models for info.
+
+        Creates 3 users, 1 of which have category preferences that match
+        categories for project2. Creates a reinvestment equal to the sum of all
+        the user's reinvestment pools. Checks that all three users will exhaust their
+        reinvest pools.
+        """
+        user1, user2, user3 = RevolvUserProfile.factories.base.create_batch(3)
+        admin1 = RevolvUserProfile.factories.admin.create()
+        project1 = Project.factories.base.create(funding_goal=200)
+        project2 = Project.factories.base.create(funding_goal=250)
+        project3 = Project.factories.base.create(funding_goal=450)
+
+        Category.factories.base.title.reset()
+        category1, category2, category3 = Category.factories.base.create_batch(3)
+
+        # assigns preferred categories for users and categories for project
+        user1.preferred_categories.add(category1)
+        user2.preferred_categories.add(category2)
+        user3.preferred_categories.add(category3)
+        project2.category_set.add(category1, category3)
+
+        self._create_payment(user1, amount=25.00, project=project1).save()
+        self._create_payment(user2, amount=75.00, project=project1).save()
+        self._create_payment(user3, amount=100.00, project=project1).save()
+        project1.complete_project()
+
+        self._create_admin_repayment(admin1, amount=400.00, project=project1).save()
+
+        # verifies that reinvestment pools have values that we expect, must reload to get new reinvest_pool amount
+        user1 = RevolvUserProfile.objects.get(pk=user1.pk)
+        user2 = RevolvUserProfile.objects.get(pk=user2.pk)
+        user3 = RevolvUserProfile.objects.get(pk=user3.pk)
+        self.assertEquals(user1.reinvest_pool, 50.00)
+        self.assertEquals(user2.reinvest_pool, 150.00)
+        self.assertEquals(user3.reinvest_pool, 200.00)
+
+        reinvest1 = self._create_admin_reinvestment(admin1, 250.00, project=project2)
+        reinvest1.save()
+
+        # checks that user 1 and user 3 donate
+        self.assertEquals(project2.amount_donated, 250.00)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).count(), 1)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
+            Sum('amount')
+        )['amount__sum'], 50.00)
         self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).count(), 0)
+        self.assertIsNone(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
+            Sum('amount')
+        )['amount__sum'])
+        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).count(), 1)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).aggregate(
+            Sum('amount')
+        )['amount__sum'], 200.00)
+        # must reload to get new reinvest_pool amount
+        user1 = RevolvUserProfile.objects.get(pk=user1.pk)
+        user2 = RevolvUserProfile.objects.get(pk=user2.pk)
+        user3 = RevolvUserProfile.objects.get(pk=user3.pk)
+        self.assertEquals(user1.reinvest_pool, 0)
+        self.assertEquals(user2.reinvest_pool, 150)
+        self.assertEquals(user3.reinvest_pool, 0)
+
+        reinvest2 = self._create_admin_reinvestment(admin1, 150.00, project=project3)
+        reinvest2.save()
+
+        # checks that user 1 and user 3 donate
+        self.assertEquals(project3.amount_donated, 150.00)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user1, project3).count(), 0)
+        self.assertIsNone(Payment.objects.reinvestment_fragments(user1, project3).aggregate(
+            Sum('amount')
+        )['amount__sum'])
+        self.assertEquals(Payment.objects.reinvestment_fragments(user2, project3).count(), 1)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user2, project3).aggregate(
+            Sum('amount')
+        )['amount__sum'], 150.00)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project3).count(), 0)
+        self.assertIsNone(Payment.objects.reinvestment_fragments(user3, project3).aggregate(
+            Sum('amount')
+        )['amount__sum'])
+        # must reload to get new reinvest_pool amount
+        user1 = RevolvUserProfile.objects.get(pk=user1.pk)
+        user2 = RevolvUserProfile.objects.get(pk=user2.pk)
+        user3 = RevolvUserProfile.objects.get(pk=user3.pk)
+        self.assertEquals(user1.reinvest_pool, 0)
+        self.assertEquals(user2.reinvest_pool, 0)
+        self.assertEquals(user3.reinvest_pool, 0)
+
+        reinvest1.delete()
+        reinvest2.delete()
+
+        # checks that after deleting, we have no reinvestment fragments
+        self.assertEquals(project2.amount_donated, 0)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user1).count(), 0)
+        self.assertIsNone(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
+            Sum('amount')
+        )['amount__sum'])
+        self.assertEquals(Payment.objects.reinvestment_fragments(user2).count(), 0)
         self.assertIsNone(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
             Sum('amount')
         )['amount__sum'])

--- a/revolv/payments/tests/models/test_payment.py
+++ b/revolv/payments/tests/models/test_payment.py
@@ -425,13 +425,15 @@ class PaymentTest(TestCase):
         Test reinvestment on AdminReinvestment level. Lots of moving parts,
         see docstrings for respective models for info.
 
-        Creates 3 users, 2 of which have category preferences that match
-        categories for project2. Checks that those 2 users will reinvest into
+        Creates 3 users, 2 of which have category preferences that match categories
+        for project2. Creates a reinvestment equal to the sum of the pools for
+        the two users with preferences. Checks that those 2 users will reinvest into
         it completely, and that the other users do not.
         """
         user1, user2, user3 = RevolvUserProfile.factories.base.create_batch(3)
         admin1 = RevolvUserProfile.factories.admin.create()
-        project1, project2 = Project.factories.base.create_batch(2)
+        project1 = Project.factories.base.create(funding_goal=200)
+        project2 = Project.factories.base.create(funding_goal=250)
 
         Category.factories.base.title.reset()
         category1, category2, category3 = Category.factories.base.create_batch(3)
@@ -480,6 +482,184 @@ class PaymentTest(TestCase):
         user3 = RevolvUserProfile.objects.get(pk=user3.pk)
         self.assertEquals(user1.reinvest_pool, 0)
         self.assertEquals(user2.reinvest_pool, 150.00)
+        self.assertEquals(user3.reinvest_pool, 0)
+
+        reinvest1.delete()
+
+        # checks that after deleting, we have no reinvestment fragments
+        self.assertEquals(project2.amount_donated, 0)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user1).count(), 0)
+        self.assertIsNone(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
+            Sum('amount')
+        )['amount__sum'])
+        self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).count(), 0)
+        self.assertIsNone(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
+            Sum('amount')
+        )['amount__sum'])
+        self.assertEquals(Payment.objects.reinvestment_fragments(user3).count(), 0)
+        self.assertIsNone(Payment.objects.reinvestment_fragments(user3, project2).aggregate(
+            Sum('amount')
+        )['amount__sum'])
+        # must reload to get new reinvest_pool amount
+        user1 = RevolvUserProfile.objects.get(pk=user1.pk)
+        user2 = RevolvUserProfile.objects.get(pk=user2.pk)
+        user3 = RevolvUserProfile.objects.get(pk=user3.pk)
+        self.assertEquals(user1.reinvest_pool, 50.00)
+        self.assertEquals(user2.reinvest_pool, 150.00)
+        self.assertEquals(user3.reinvest_pool, 200.00)
+
+    def test_admin_reinvestment_leftover_reinvest_pool(self):
+        """
+        Test reinvestment on AdminReinvestment level. Lots of moving parts,
+        see docstrings for respective models for info.
+
+        Creates 3 users, 2 of which have category preferences that match
+        categories for project2. Creates a reinvestment large enough to exhaust
+        the pools of users with preferences, and use some from the user without
+        preferences. Checks that those 2 users will reinvest into
+        it completely, and that the other user will invest the remainder and
+        have leftover funds after the project hits its reinvestment goal.
+        """
+        user1, user2, user3 = RevolvUserProfile.factories.base.create_batch(3)
+        admin1 = RevolvUserProfile.factories.admin.create()
+        project1 = Project.factories.base.create(funding_goal=200)
+        project2 = Project.factories.base.create(funding_goal=350)
+
+        Category.factories.base.title.reset()
+        category1, category2, category3 = Category.factories.base.create_batch(3)
+
+        # assigns preferred categories for users and categories for project
+        user1.preferred_categories.add(category2)
+        user2.preferred_categories.add(category3)
+        user3.preferred_categories.add(category1, category3)
+        project2.category_set.add(category1, category2)
+
+        self._create_payment(user1, amount=25.00, project=project1).save()
+        self._create_payment(user2, amount=75.00, project=project1).save()
+        self._create_payment(user3, amount=100.00, project=project1).save()
+        project1.complete_project()
+
+        self._create_admin_repayment(admin1, amount=400.00, project=project1).save()
+
+        # verifies that reinvestment pools have values that we expect, must reload to get new reinvest_pool amount
+        user1 = RevolvUserProfile.objects.get(pk=user1.pk)
+        user2 = RevolvUserProfile.objects.get(pk=user2.pk)
+        user3 = RevolvUserProfile.objects.get(pk=user3.pk)
+        self.assertEquals(user1.reinvest_pool, 50.00)
+        self.assertEquals(user2.reinvest_pool, 150.00)
+        self.assertEquals(user3.reinvest_pool, 200.00)
+
+        reinvest1 = self._create_admin_reinvestment(admin1, 350.00, project=project2)
+        reinvest1.save()
+
+        # checks that all three users donate, and user 2, the user with no preferences,
+        # has leftover funds
+        self.assertEquals(project2.amount_donated, 350.00)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user1).count(), 1)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
+            Sum('amount')
+        )['amount__sum'], 50.00)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).count(), 1)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).aggregate(
+            Sum('amount')
+        )['amount__sum'], 200.00)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).count(), 1)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
+            Sum('amount')
+        )['amount__sum'], 100.00)
+        # must reload to get new reinvest_pool amount
+        user1 = RevolvUserProfile.objects.get(pk=user1.pk)
+        user2 = RevolvUserProfile.objects.get(pk=user2.pk)
+        user3 = RevolvUserProfile.objects.get(pk=user3.pk)
+        self.assertEquals(user1.reinvest_pool, 0)
+        self.assertEquals(user2.reinvest_pool, 50.00)
+        self.assertEquals(user3.reinvest_pool, 0)
+
+        reinvest1.delete()
+
+        # checks that after deleting, we have no reinvestment fragments
+        self.assertEquals(project2.amount_donated, 0)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user1).count(), 0)
+        self.assertIsNone(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
+            Sum('amount')
+        )['amount__sum'])
+        self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).count(), 0)
+        self.assertIsNone(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
+            Sum('amount')
+        )['amount__sum'])
+        self.assertEquals(Payment.objects.reinvestment_fragments(user3).count(), 0)
+        self.assertIsNone(Payment.objects.reinvestment_fragments(user3, project2).aggregate(
+            Sum('amount')
+        )['amount__sum'])
+        # must reload to get new reinvest_pool amount
+        user1 = RevolvUserProfile.objects.get(pk=user1.pk)
+        user2 = RevolvUserProfile.objects.get(pk=user2.pk)
+        user3 = RevolvUserProfile.objects.get(pk=user3.pk)
+        self.assertEquals(user1.reinvest_pool, 50.00)
+        self.assertEquals(user2.reinvest_pool, 150.00)
+        self.assertEquals(user3.reinvest_pool, 200.00)
+
+    def test_admin_reinvestment_depleted_reinvestment_pool(self):
+        """
+        Test reinvestment on AdminReinvestment level. Lots of moving parts,
+        see docstrings for respective models for info.
+
+        Creates 3 users, 1 of which have category preferences that match
+        categories for project2. Creates a reinvestment equal to the sum of all
+        the user's reinvestment pools. Checks that all three users will exhaust their
+        reinvest pools.
+        """
+        user1, user2, user3 = RevolvUserProfile.factories.base.create_batch(3)
+        admin1 = RevolvUserProfile.factories.admin.create()
+        project1 = Project.factories.base.create(funding_goal=200)
+        project2 = Project.factories.base.create(funding_goal=450)
+
+        Category.factories.base.title.reset()
+        category1, category2, category3 = Category.factories.base.create_batch(3)
+
+        # assigns preferred categories for users and categories for project
+        user1.preferred_categories.add(category2)
+        user2.preferred_categories.add(category3)
+        project2.category_set.add(category1, category2)
+
+        self._create_payment(user1, amount=25.00, project=project1).save()
+        self._create_payment(user2, amount=75.00, project=project1).save()
+        self._create_payment(user3, amount=100.00, project=project1).save()
+        project1.complete_project()
+
+        self._create_admin_repayment(admin1, amount=400.00, project=project1).save()
+
+        # verifies that reinvestment pools have values that we expect, must reload to get new reinvest_pool amount
+        user1 = RevolvUserProfile.objects.get(pk=user1.pk)
+        user2 = RevolvUserProfile.objects.get(pk=user2.pk)
+        user3 = RevolvUserProfile.objects.get(pk=user3.pk)
+        self.assertEquals(user1.reinvest_pool, 50.00)
+        self.assertEquals(user2.reinvest_pool, 150.00)
+        self.assertEquals(user3.reinvest_pool, 200.00)
+
+        reinvest1 = self._create_admin_reinvestment(admin1, 400.00, project=project2)
+        reinvest1.save()
+
+        # checks that all three users donate, and that all of their reinvest pools are depleted
+        self.assertEquals(project2.amount_donated, 400.00)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user1).count(), 1)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user1, project2).aggregate(
+            Sum('amount')
+        )['amount__sum'], 50.00)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).count(), 1)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user3, project2).aggregate(
+            Sum('amount')
+        )['amount__sum'], 200.00)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).count(), 1)
+        self.assertEquals(Payment.objects.reinvestment_fragments(user2, project2).aggregate(
+            Sum('amount')
+        )['amount__sum'], 150.00)
+        # must reload to get new reinvest_pool amount
+        user1 = RevolvUserProfile.objects.get(pk=user1.pk)
+        user2 = RevolvUserProfile.objects.get(pk=user2.pk)
+        user3 = RevolvUserProfile.objects.get(pk=user3.pk)
+        self.assertEquals(user1.reinvest_pool, 0)
+        self.assertEquals(user2.reinvest_pool, 0)
         self.assertEquals(user3.reinvest_pool, 0)
 
         reinvest1.delete()

--- a/revolv/project/migrations/0037_auto_20150414_0117.py
+++ b/revolv/project/migrations/0037_auto_20150414_0117.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations, models
 
 
 class Migration(migrations.Migration):

--- a/revolv/project/migrations/0037_auto_20150414_0117.py
+++ b/revolv/project/migrations/0037_auto_20150414_0117.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('project', '0036_merge'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='project',
+            name='post_funding_updates',
+        ),
+        migrations.AlterField(
+            model_name='projectupdate',
+            name='project',
+            field=models.ForeignKey(related_name=b'updates', to='project.Project'),
+        ),
+    ]

--- a/revolv/project/tests/test_models.py
+++ b/revolv/project/tests/test_models.py
@@ -1,24 +1,25 @@
-import mock
-import json
 import datetime
+import json
+
+import mock
 from django.test import TestCase
-from revolv.project.models import Category, Project, ProjectUpdate, Payment
-from revolv.lib.testing import TestUserMixin, UserTestingMixin
+
 from django_webtest import WebTest
 from revolv.base.models import RevolvUserProfile
 from revolv.lib.testing import TestUserMixin
 from revolv.payments.models import (AdminReinvestment, AdminRepayment, Payment,
                                     PaymentType)
-from revolv.project.models import Category, Project
+from revolv.project.models import Category, Project, ProjectUpdate
 from revolv.project.tasks import scrape
+
 
 class ProjectUpdateTest(TestCase):
     """Tests that check that project updates work with projects"""
 
     def test_construct(self):
         project = Project.factories.base.create()
-        update1 = ProjectUpdate(update_text = 'This is update text', project=project)
-        update2 = ProjectUpdate(update_text = 'This is another update', project=project)
+        update1 = ProjectUpdate(update_text='This is update text', project=project)
+        update2 = ProjectUpdate(update_text='This is another update', project=project)
 
         # tests basic construction
         self.assertEqual('This is update text', update1.update_text)
@@ -30,13 +31,14 @@ class ProjectUpdateTest(TestCase):
 
         update1.save()
         update2.save()
-        self.assertEqual(len(ProjectUpdate.objects.all()),2)
+        self.assertEqual(len(ProjectUpdate.objects.all()), 2)
 
     def test_add_update(self):
         project = Project.factories.base.create()
         project.add_update('Another sample update')
         update = ProjectUpdate.objects.get(update_text='Another sample update')
         self.assertEqual(project, update.project)
+
 
 class ProjectTests(TestCase):
     """Project model tests."""
@@ -211,6 +213,7 @@ class CategoryTest(TestCase):
     def test_update_category(self):
         """ Test that updating a single projects category works """
         project = Project.factories.base.create()
+        Category.factories.base.title.reset()
         category1, category2 = Category.factories.base.create_batch(2)
         # tests that associating two categories with the project works
         project.update_categories(Category.valid_categories[:2])
@@ -253,7 +256,7 @@ class ProjectIntegrationTest(WebTest):
         project = Project.factories.active.create()
         resp = self.app.get("/project/%d/" % project.pk, auto_follow=True)
         self.assertEqual(resp.status_code, 200)
-        
+
         # note: if the link makes a modal appear, it will be skipped and the
         # test will fail because it couldn't find the link - this is what
         # we want to happen in this case, but we may have to change this if


### PR DESCRIPTION
Fixes #80 

Added a preferred_categories field to RevolvUserProfile
Updated post_save_admin_reinvestment to take categories (user preferences) into account.
Added tests.