### PR TITLE
Change paypal charging back to always on

### DIFF
--- a/revolv/settings.py
+++ b/revolv/settings.py
@@ -309,4 +309,4 @@ actually do get charged.
 Consequently, it's safe to always enable charging, since in development nothing
 is actually being charged on the PayPal side.
 """
-ENABLE_PAYMENT_CHARGING = False
+ENABLE_PAYMENT_CHARGING = IS_HEROKU

--- a/revolv/settings.py
+++ b/revolv/settings.py
@@ -309,4 +309,4 @@ actually do get charged.
 Consequently, it's safe to always enable charging, since in development nothing
 is actually being charged on the PayPal side.
 """
-ENABLE_PAYMENT_CHARGING = IS_HEROKU
+ENABLE_PAYMENT_CHARGING = True


### PR DESCRIPTION
I thought about only turning on charging for staging and prod, not local, but I decided against it in an effort to make all the environments as much the same as possible. @aykamko I'd like your opinion, do you think we should just never actually validate via paypal api on local?