### PR TITLE
Fixed signup subscribed to newsletter error

### DIFF
--- a/revolv/base/forms.py
+++ b/revolv/base/forms.py
@@ -13,7 +13,7 @@ class SignupForm(UserCreationForm):
     email = forms.EmailField(label="Email")
     first_name = forms.CharField(label="First name")
     last_name = forms.CharField(label="Last name")
-    subscribed_to_newsletter = forms.BooleanField(initial=True, label="Subscribe me to the Re-volv Newsletter.", help_text="Subscribe me to the Revolv Newsletter")
+    subscribed_to_newsletter = forms.BooleanField(initial=True, required=False, label="Subscribe me to the Re-volv Newsletter.", help_text="Subscribe me to the Revolv Newsletter")
 
     def save(self, commit=True):
         """


### PR DESCRIPTION
Fixes #303 

Fixes bugs where users can't signup if they don't subscribe to the newsletter.

Simply changed required to be False for that field.

http://stackoverflow.com/questions/16955256/booleanfield-default-value-not-set-when-creating-a-model-instance