### PR TITLE
Serve static assets from s3

### DIFF
--- a/revolv/custom_storages.py
+++ b/revolv/custom_storages.py
@@ -26,10 +26,10 @@ from storages.backends.s3boto import S3BotoStorage
 
 
 class RevolvProductionStaticStorage(S3BotoStorage):
-    """Storage that tells boto to collect files into the staging directory in our S3 bucket."""
+    """Storage that tells boto to collect files into the production directory in our S3 bucket."""
     location = settings.STATICFILES_PRODUCTION_LOCATION
 
 
 class RevolvStagingStaticStorage(S3BotoStorage):
-    """Storage that tells boto to collect files into the production directory in our S3 bucket."""
+    """Storage that tells boto to collect files into the staging directory in our S3 bucket."""
     location = settings.STATICFILES_STAGING_LOCATION

--- a/revolv/custom_storages.py
+++ b/revolv/custom_storages.py
@@ -1,7 +1,7 @@
 """
 Custom storage settings used to ensure that static files collected
 to Amazon s3 aren't just dropped in the root of the bucket (and instead
-are collected to a bucket's subdirectory).
+are collected to a subdirectory of the bucket).
 
 See https://www.caktusgroup.com/blog/2014/11/10/Using-Amazon-S3-to-store-your-Django-sites-static-and-media-files/
 

--- a/revolv/custom_storages.py
+++ b/revolv/custom_storages.py
@@ -1,0 +1,35 @@
+"""
+Custom storage settings used to ensure that static files collected
+to Amazon s3 aren't just dropped in the root of the bucket (and instead
+are collected to a bucket's subdirectory).
+
+See https://www.caktusgroup.com/blog/2014/11/10/Using-Amazon-S3-to-store-your-Django-sites-static-and-media-files/
+
+One note: we define two different kinds of "storages" here, because we
+want to separate the staticfiles that are served on staging with those
+served on production (e.g., if we push new staticfiles to staging, we
+don't want those to be seen on production yet until we're sure they work).
+
+So, we need to make sure that we run collectstatic twice when deploying
+this application: once after pushing new code to staging, which will collect
+the static files into the /static_staging/ directory (or whatever we define
+the directory name to be in settings.py) and once on production, which will
+collect all the static files to the /static_production/ directory in our S3
+bucket.
+
+TODO: we should use three different buckets entirely for the production, staging,
+and local development environments. See https://github.com/calblueprint/revolv/issues/352
+"""
+
+from django.conf import settings
+from storages.backends.s3boto import S3BotoStorage
+
+
+class RevolvProductionStaticStorage(S3BotoStorage):
+    """Storage that tells boto to collect files into the staging directory in our S3 bucket."""
+    location = settings.STATICFILES_PRODUCTION_LOCATION
+
+
+class RevolvStagingStaticStorage(S3BotoStorage):
+    """Storage that tells boto to collect files into the production directory in our S3 bucket."""
+    location = settings.STATICFILES_STAGING_LOCATION

--- a/revolv/settings.py
+++ b/revolv/settings.py
@@ -37,10 +37,7 @@ FACEBOOK_APP_ID = os.environ.get("REVOLV_FACEBOOK_APP_ID")
 FACEBOOK_APP_SECRET = os.environ.get("REVOLV_FACEBOOK_APP_SECRET")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-# TODO: static files will not serve with debug turned off, so we need
-# to move staticfile serving to Amazon in order to turn off DEBUG.
-# see https://github.com/calblueprint/revolv/issues/135
-DEBUG = IS_LOCAL or IS_STAGE
+DEBUG = IS_LOCAL
 
 TEMPLATE_DEBUG = IS_LOCAL
 

--- a/revolv/settings.py
+++ b/revolv/settings.py
@@ -178,37 +178,54 @@ USE_THOUSAND_SEPARATOR = True
 # Login settings
 LOGIN_URL = '/signin'
 
-# Static asset configuration
-STATIC_ROOT = 'staticfiles'
-
-# Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.7/howto/static-files/
-STATIC_URL = '/static/'
-STATICFILES_DIRS = (
-    os.path.join(BASE_DIR, 'static'),
-)
-
-STATICFILES_FINDERS = (
-    'django.contrib.staticfiles.finders.FileSystemFinder',
-    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    'djangobower.finders.BowerFinder',
-)
-
-# djangobower settings
-BOWER_COMPONENTS_ROOT = os.path.join(BASE_DIR, 'static')
-BOWER_INSTALLED_APPS = (
-    'foundation',
-)
-
+# Default media file (uploads) storage on Amazon S3
 DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 
 AWS_ACCESS_KEY_ID = os.environ.get('REVOLV_AWS_ACCESS_KEY_ID', '')
 AWS_SECRET_ACCESS_KEY = os.environ.get('REVOLV_AWS_SECRET_KEY', '')
 AWS_STORAGE_BUCKET_NAME = os.environ.get('REVOLV_S3_BUCKET', '')
 
-S3_URL = 'http://%s.s3.amazonaws.com' % AWS_STORAGE_BUCKET_NAME
+S3_URL = 'https://%s.s3.amazonaws.com' % AWS_STORAGE_BUCKET_NAME
 MEDIA_DIRECTORY = '/media/'
 MEDIA_URL = S3_URL + MEDIA_DIRECTORY
+
+STATIC_ROOT = 'staticfiles'
+STATICFILES_FINDERS = (
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    'djangobower.finders.BowerFinder',
+)
+STATICFILES_DIRS = (
+    os.path.join(BASE_DIR, 'static'),
+)
+
+if IS_LOCAL:
+    # On local, we use django's built in static files app, which will serve
+    # static files (css, js, etc) directly from the project directory called
+    # "static" (that directory is a sibling of this file in the directory tree)
+    # See https://docs.djangoproject.com/en/1.7/howto/static-files/
+    STATIC_URL = '/static/'
+else:
+    # on staging/production, we use Amazon S3 for storage.
+    # See https://www.caktusgroup.com/blog/2014/11/10/Using-Amazon-S3-to-store-your-Django-sites-static-and-media-files/
+
+    # the bucket directory in which to collect static files for staging
+    STATICFILES_STAGING_LOCATION = "static_staging"
+    # the corresponding bucket directory for static files on prod
+    STATICFILES_PRODUCTION_LOCATION = "static_production"
+    if IS_PROD:
+        staticfiles_location = STATICFILES_PRODUCTION_LOCATION
+        STATICFILES_STORAGE = 'revolv.custom_storages.RevolvProductionStaticStorage'
+    else:
+        staticfiles_location = STATICFILES_STAGING_LOCATION
+        STATICFILES_STORAGE = 'revolv.custom_storages.RevolvStagingStaticStorage'
+    STATIC_URL = "%s/%s/" % (S3_URL, staticfiles_location)
+
+# djangobower settings
+BOWER_COMPONENTS_ROOT = os.path.join(BASE_DIR, 'static')
+BOWER_INSTALLED_APPS = (
+    'foundation',
+)
 
 # email settings
 # see http://stackoverflow.com/questions/9723494/setting-up-email-with-sendgrid-in-heroku-for-a-django-app


### PR DESCRIPTION
Fixes #135 and also fixes #342. Not much to change here actually! @vivekraghuram I updated settings to serve stuff from s3, and I also logged onto the AWS console and updated the bucket settings to be publicly viewable and CORSable from our domains. Note: when pushing from now on, we'll need to add `manage.py collectstatic` in addition to `migrate` in order to copy new static files over to s3 - I'll add this to the codeship build. Can you lgtm this quickly? :D