### PR TITLE
Functionality for unapproving projects

### DIFF
--- a/revolv/project/models.py
+++ b/revolv/project/models.py
@@ -273,6 +273,16 @@ class Project(models.Model):
         self.save()
         return self
 
+    def unapprove_project(self):
+        """
+        TODO (https://github.com/calblueprint/revolv/issues/255): when we add
+        a STAGED project status, the "unapprove" action should make the project
+        STAGED, not PROPOSED.
+        """
+        self.project_status = Project.PROPOSED
+        self.save()
+        return self
+
     def propose_project(self):
         self.project_status = Project.PROPOSED
         self.save()

--- a/revolv/project/models.py
+++ b/revolv/project/models.py
@@ -2,10 +2,9 @@
 import datetime
 from itertools import chain
 
+from ckeditor.fields import RichTextField
 from django.core.urlresolvers import reverse
 from django.db import models
-
-from ckeditor.fields import RichTextField
 from imagekit.models import ImageSpecField, ProcessedImageField
 from imagekit.processors import ResizeToFill
 from revolv.base.models import RevolvUserProfile

--- a/revolv/project/views.py
+++ b/revolv/project/views.py
@@ -132,8 +132,11 @@ class ReviewProjectView(UserDataMixin, UpdateView):
     def form_valid(self, form):
         project = self.object
         if '_approve' in self.request.POST:
-            messages.success(self.request, project.title + ' has been approved')
+            messages.success(self.request, project.title + ' has been approved and is live.')
             project.approve_project()
+        elif '_unapprove' in self.request.POST:
+            messages.success(self.request, project.title + ' is no longer live.')
+            project.unapprove_project()
         elif '_propose' in self.request.POST:
             messages.success(self.request, project.title + ' is now pending approval')
             project.propose_project()

--- a/revolv/static/dashboard.css
+++ b/revolv/static/dashboard.css
@@ -7899,8 +7899,11 @@ html, body, .main-row {
     display: inline-block; }
   .dashboard-project .controls {
     text-align: right; }
-    .dashboard-project .controls form {
-      margin-right: 30px; } }
+    .dashboard-project .controls form, .dashboard-project .controls form.input {
+      margin-right: 0;
+      margin-left: 10px; }
+      .dashboard-project .controls form:first-child, .dashboard-project .controls form.input:first-child {
+        margin-left: 0; } }
 
 @media only screen and (min-width:40.063em) and (max-width:64em) {
   .dashboard-project .dashboard-project-header .project-status-medium {

--- a/revolv/static/dashboard.scss
+++ b/revolv/static/dashboard.scss
@@ -624,8 +624,12 @@ $dark-gray: #555555;
         }
         .controls {
             text-align: right;
-            form {
-                margin-right: 30px;
+            form, form.input {
+                margin-right: 0;
+                margin-left: 10px;
+                &:first-child {
+                    margin-left: 0;
+                }
             }
         }
     }

--- a/revolv/templates/base/partials/project_controls.html
+++ b/revolv/templates/base/partials/project_controls.html
@@ -34,6 +34,7 @@
             <form id="complete_form_{{project.pk}}" enctype="multipart/form-data" method="POST" action="{% url "project:review" pk=project.id %}">
                 {% csrf_token %}
                 <input id="complete_project" class="small button success" name="_complete" type="submit" value="Complete" />
+                <input id="complete_project" class="small button alert" name="_unapprove" type="submit" value="Mark as proposed" />
             </form>
         {% endif %}
         {% if project.is_completed or project.is_active %}


### PR DESCRIPTION
Fixes #234 

Pretty small fix, puts in a button for the admins to use to mark an active project as back to proposed. Bonus: fixes #331 because it was kinda related to the button style fixes that I had to make.

@erictshen can you give this a quick review please?

![screen shot 2015-06-18 at 5 37 31 pm](https://cloud.githubusercontent.com/assets/1168853/8243879/cfeae820-15e0-11e5-81a7-ab774ed79985.png)
