### PR TITLE
TOS blurb on the signin page

### DIFF
--- a/revolv/revolv_cms/migrations/0008_signuppagesettings_tos_paragraph.py
+++ b/revolv/revolv_cms/migrations/0008_signuppagesettings_tos_paragraph.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
 import wagtail.wagtailcore.fields
+from django.db import migrations, models
 
 
 class Migration(migrations.Migration):

--- a/revolv/revolv_cms/migrations/0008_signuppagesettings_tos_paragraph.py
+++ b/revolv/revolv_cms/migrations/0008_signuppagesettings_tos_paragraph.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import wagtail.wagtailcore.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('revolv_cms', '0007_paymentmodalsettings_confirm_payment_paragraph'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='signuppagesettings',
+            name='tos_paragraph',
+            field=wagtail.wagtailcore.fields.RichTextField(default=b"<p>Signing up for an account means joining the RE-volv community and agreeing to the <a href='/tos'>terms of service</a>. RE-volv will never store credit card information and will never give your information to third parties. Welcome!</p>", help_text=b'The paragraph to display directly after the form but before the sign up button. Should include a link to the Terms of Service page.', blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/revolv/revolv_cms/models.py
+++ b/revolv/revolv_cms/models.py
@@ -174,6 +174,11 @@ class SignupPageSettings(BaseSetting):
         help_text="The paragraph of text to be shown under the heading on the sign up page, but before the link to the login page.",
         default="<p>Start investing in renewable solar energy by signing up for an account.</p>"
     )
+    tos_paragraph = RichTextField(
+        blank=True,
+        help_text="The paragraph to display directly after the form but before the sign up button. Should include a link to the Terms of Service page.",
+        default="<p>Signing up for an account means joining the RE-volv community and agreeing to the <a href='/tos'>terms of service</a>. RE-volv will never store credit card information and will never give your information to third parties. Welcome!</p>"
+    )
     button_text = models.CharField(
         max_length=30,
         help_text="The text on the actual sign up button, e.g. 'Sign up'",

--- a/revolv/revolv_cms/models.py
+++ b/revolv/revolv_cms/models.py
@@ -177,7 +177,7 @@ class SignupPageSettings(BaseSetting):
     tos_paragraph = RichTextField(
         blank=True,
         help_text="The paragraph to display directly after the form but before the sign up button. Should include a link to the Terms of Service page.",
-        default="<p>Signing up for an account means joining the RE-volv community and agreeing to the <a href='/tos'>terms of service</a>. RE-volv will never store credit card information and will never give your information to third parties. Welcome!</p>"
+        default="<p>Signing up for an account means joining the RE-volv community and agreeing to the <a href='/tos/'>terms of service</a>. RE-volv will never store credit card information and will never give your information to third parties. Welcome!</p>"
     )
     button_text = models.CharField(
         max_length=30,

--- a/revolv/static/auth.css
+++ b/revolv/static/auth.css
@@ -27,6 +27,12 @@ small.field-error {
   background-color: transparent;
   color: #f46b7b; }
 
+.paragraph-field-label p {
+  font-family: inherit;
+  font-weight: normal;
+  color: #555555;
+  font-size: 14px; }
+
 .submit-button {
   margin: 0;
   width: 100%;

--- a/revolv/static/dashboard.css
+++ b/revolv/static/dashboard.css
@@ -7367,6 +7367,12 @@ small.field-error {
   background-color: transparent;
   color: #f46b7b; }
 
+.paragraph-field-label p {
+  font-family: inherit;
+  font-weight: normal;
+  color: #555555;
+  font-size: 14px; }
+
 .submit-button {
   margin: 0;
   width: 100%;

--- a/revolv/static/placeholder-formfield.scss
+++ b/revolv/static/placeholder-formfield.scss
@@ -33,6 +33,13 @@ small.field-error { // extra qualifiers to override foundation
     color: $revolv-error-color;
 }
 
+.paragraph-field-label p {
+    font-family: inherit;
+    font-weight: normal;
+    color: #555;
+    font-size: 14px;
+}
+
 .submit-button {
     margin: 0;
     width: 100%;

--- a/revolv/templates/base/sign_in.html
+++ b/revolv/templates/base/sign_in.html
@@ -70,6 +70,9 @@
             <label class="checkbox-field-label">
             {{ signup_form.subscribed_to_newsletter }}<span>{{signup_form.subscribed_to_newsletter.label}}</span>
             </label>
+            <label class="paragraph-field-label">
+                {{ settings.revolv_cms.SignupPageSettings.tos_paragraph|safe }}
+            </label>
             <button class="submit-button medium" type="submit" value="Log in">{{ settings.revolv_cms.SignupPageSettings.button_text }}</button>
         </form>
     </div>


### PR DESCRIPTION
Fixes #304 

Just added a CMS setting for a blurb about the TOS, pretty simple. The link in the default for this field might not actually exist, but that's okay because it's CMS customizable.

@vivekraghuram can you give this a quick look?

![screen shot 2015-06-21 at 7 25 00 pm](https://cloud.githubusercontent.com/assets/1168853/8274059/3282c03e-184d-11e5-9e4d-0f205f0e88d0.png)
