### PR TITLE
Fix staging issues

### DIFF
--- a/revolv/revolv_cms/tests.py
+++ b/revolv/revolv_cms/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/revolv/revolv_cms/tests/test_general.py
+++ b/revolv/revolv_cms/tests/test_general.py
@@ -1,11 +1,25 @@
 from django_webtest import WebTest
+from django.test.utils import override_settings
 
 
 class GeneralTest(WebTest):
+
     def test_admin_pages_work(self):
         """
         Test that the app doesn't error when going to /cms/. Tests like
         this could have avoided https://github.com/calblueprint/revolv/issues/362
+        """
+        resp = self.app.get("/cms/").maybe_follow()
+        self.assertEqual(resp.status_code, 200)
+
+    @override_settings(DEBUG=False, COMPRESS_ENABLED=True)
+    def test_admin_pages_work_with_django_compressor(self):
+        """
+        Test that the cms admin page doesn't error when django-compressor
+        is enabled. Django-compressor is a dependency for wagtail, but
+        it behaves differently with regards to staticfiles on local
+        and staging/prod, resulting in https://github.com/calblueprint/revolv/issues/362
+        This test exposes that error.
         """
         resp = self.app.get("/cms/").maybe_follow()
         self.assertEqual(resp.status_code, 200)

--- a/revolv/revolv_cms/tests/test_general.py
+++ b/revolv/revolv_cms/tests/test_general.py
@@ -1,5 +1,5 @@
-from django_webtest import WebTest
 from django.test.utils import override_settings
+from django_webtest import WebTest
 
 
 class GeneralTest(WebTest):

--- a/revolv/revolv_cms/tests/test_general.py
+++ b/revolv/revolv_cms/tests/test_general.py
@@ -1,0 +1,11 @@
+from django_webtest import WebTest
+
+
+class GeneralTest(WebTest):
+    def test_admin_pages_work(self):
+        """
+        Test that the app doesn't error when going to /cms/. Tests like
+        this could have avoided https://github.com/calblueprint/revolv/issues/362
+        """
+        resp = self.app.get("/cms/").maybe_follow()
+        self.assertEqual(resp.status_code, 200)

--- a/revolv/settings.py
+++ b/revolv/settings.py
@@ -42,6 +42,10 @@ FACEBOOK_APP_SECRET = os.environ.get("REVOLV_FACEBOOK_APP_SECRET")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = IS_LOCAL
+# disable django-compressor for wagtail admin pages. this is hacky
+# but necessary until we can get it to play nicer with s3.
+# see https://github.com/calblueprint/revolv/issues/363
+COMPRESS_ENABLED = False
 
 TEMPLATE_DEBUG = IS_LOCAL
 
@@ -195,6 +199,7 @@ STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     'djangobower.finders.BowerFinder',
+    'compressor.finders.CompressorFinder'  # for the {% compress %} tags in wagtail to work
 )
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'static'),


### PR DESCRIPTION
Fixes #362 

Disable django-compressor. I am pretty sure this should fix the issue of the CMS pages 500ing on staging. This is a super short change, so I don't need anyone to review it, but I will leave it open for a while in case anyone wants to comment.

Also codeship is failing and I have no idea why...but it's failing in the same way on master, so I won't worry about it for now