### PR TITLE
Enable bower on heroku so collectstatic will work correctly

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/heroku/heroku-buildpack-nodejs#v76
+git://github.com/heroku/heroku-buildpack-python.git

--- a/package.json
+++ b/package.json
@@ -6,10 +6,14 @@
     "grunt-contrib-watch": "~0.5.3",
     "grunt-sass": "~0.8.0"
   },
+  "dependencies": {
+    "bower": "^1.4.1"
+  },
   "description": "About Blueprint ======= We strive to make beautiful engineering accessible and useful for those who create communities and promote public welfare. Our vision is a world where the good, passionate, and visionary have the biggest impact on our communities and society.",
   "main": "Gruntfile.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "postinstall": "./node_modules/bower/bin/bower install"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
There is a problem on staging right now. Since we deployed static assets to s3 in #353, we have to run `manage.py collectstatic` on deploy in order for the s3 files to be updated. This is okay, and heroku tries to do this by default. However, the problem is that our staticfiles configuration includes the bower_components directory, which is empty on staging. This causes collectstatic to error and I believe this is why the styles that we put in in #361 aren't appearing correctly on staging right now.

SO, to fix this, I added a buildpack for heroku which installs npm dependencies (the only one now is bower) and, after installing, runs `bower install`. So hopefully now, collectstatic will know where to find things and will not fail.

If anyone wants to look over this go for it, I'll merge it in a few hours.