### PR TITLE
Fixes #366: Add settings to db seed

### DIFF
--- a/revolv/base/tests/test_management.py
+++ b/revolv/base/tests/test_management.py
@@ -4,6 +4,7 @@ from django.test import TestCase
 from revolv.base.models import RevolvUserProfile
 from revolv.payments.models import Payment
 from revolv.project.models import Project
+from revolv.revolv_cms.models import MainPageSettings
 
 
 class SeedTest(TestCase):
@@ -38,6 +39,13 @@ class SeedTest(TestCase):
         self.assertEqual(RevolvUserProfile.objects.count(), profile_count)
         self.assertEqual(Project.objects.count(), project_count)
         self.assertEqual(Payment.objects.count(), payment_count)
+
+    def test_seed_cms_settings(self):
+        """Assert the seed for the cms settings works."""
+        call_command("seed", quiet=True)
+        # for MainPageSettings, there can be only one, so we just want to assert
+        # that it's there.
+        self.assertEqual(MainPageSettings.objects.count(), 1)
 
     def test_cms_seed(self):
         """


### PR DESCRIPTION
Fixes #366 for @andylouisqin 

So, before this, there were wagtail settings models defined, with
default values, but in order to get them to actually show up on pages,
you had to go to the settings page and save each one.

This is because the register_setting decorator doesn't actually create
instances of the models (nor should it). So, to eliminate unecessary
work, I added the cms models to a seed file. It also automatically seeds
all registered settings, so no need to worry about editing the seed spec
for settings after defining a new setting.

Will merge later!