### PR TITLE
Remove geographic category 

### DIFF
--- a/revolv/project/migrations/0053_auto_20150722_0413.py
+++ b/revolv/project/migrations/0053_auto_20150722_0413.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from revolv.project.models import Category
+
+
+def remove_geographic_category(apps, schema_editor):
+    Category.objects.get_or_create(title='Geographic')[0].delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('project', '0052_auto_20150630_2238'),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_geographic_category),
+    ]

--- a/revolv/project/models.py
+++ b/revolv/project/models.py
@@ -679,9 +679,8 @@ class Category(models.Model):
     FAITH = 'Faith'
     EDUCATION = 'Education'
     COMMUNITY = 'Community'
-    GEOGRAPHIC = 'Geographic'
 
-    valid_categories = [HEALTH, ARTS, FAITH, EDUCATION, COMMUNITY, GEOGRAPHIC]
+    valid_categories = [HEALTH, ARTS, FAITH, EDUCATION, COMMUNITY]
 
     factories = ImportProxy("revolv.project.factories", "CategoryFactories")
 


### PR DESCRIPTION
Can't remember if I did this the proper django way. Removed the category so the original data migration that creates them shouldn't event make the geographic category. The new data migration should remove it from any existing databases. Resolves #376 

@noahsark769 sí?