### PR TITLE
Content page models & styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ node_modules/
 celerybeat.pid
 # IDEA
 .idea
+
+# RE-volv dist
+revolv/media/

--- a/revolv/revolv_cms/migrations/0032_auto_20160204_1405.py
+++ b/revolv/revolv_cms/migrations/0032_auto_20160204_1405.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import wagtail.wagtailcore.fields
+import wagtail.wagtailcore.blocks
+import wagtail.wagtailimages.blocks
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('revolv_cms', '0031_auto_20160131_2213'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='revolvcustompage',
+            name='body',
+            field=wagtail.wagtailcore.fields.StreamField([(b'rich_text', wagtail.wagtailcore.blocks.RichTextBlock()), (b'image', wagtail.wagtailcore.blocks.StructBlock([(b'image', wagtail.wagtailimages.blocks.ImageChooserBlock()), (b'size', wagtail.wagtailcore.blocks.ChoiceBlock(default=b'medium', choices=[(b'tiny', b'Tiny'), (b'small', b'Small'), (b'medium', b'Medium'), (b'large', b'Large')])), (b'layout', wagtail.wagtailcore.blocks.ChoiceBlock(default=b'inline', choices=[(b'img-inline', b'Inline'), (b'img-block', b'Block'), (b'img-left', b'Float Left'), (b'img-right', b'Float Right')]))]))]),
+            preserve_default=True,
+        ),
+    ]

--- a/revolv/revolv_cms/migrations/0033_auto_20160204_1419.py
+++ b/revolv/revolv_cms/migrations/0033_auto_20160204_1419.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import wagtail.wagtailcore.fields
+import wagtail.wagtailcore.blocks
+import wagtail.wagtailimages.blocks
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('revolv_cms', '0032_auto_20160204_1405'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='revolvcustompage',
+            name='body',
+            field=wagtail.wagtailcore.fields.StreamField([(b'rich_text', wagtail.wagtailcore.blocks.RichTextBlock()), (b'image', wagtail.wagtailcore.blocks.StructBlock([(b'image', wagtail.wagtailimages.blocks.ImageChooserBlock()), (b'size', wagtail.wagtailcore.blocks.ChoiceBlock(default=b'medium', choices=[(b'tiny', b'Tiny'), (b'small', b'Small'), (b'medium', b'Medium'), (b'large', b'Large'), (b'full_width', b'Full Width')])), (b'layout', wagtail.wagtailcore.blocks.ChoiceBlock(default=b'inline', choices=[(b'img-inline', b'Inline'), (b'img-block', b'Block'), (b'img-left', b'Float Left'), (b'img-right', b'Float Right')]))]))]),
+            preserve_default=True,
+        ),
+    ]

--- a/revolv/revolv_cms/migrations/0034_auto_20160204_1759.py
+++ b/revolv/revolv_cms/migrations/0034_auto_20160204_1759.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import wagtail.wagtailcore.fields
+import wagtail.wagtailcore.blocks
+import wagtail.wagtailimages.blocks
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('revolv_cms', '0033_auto_20160204_1419'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='revolvcustompage',
+            name='body',
+            field=wagtail.wagtailcore.fields.StreamField([(b'rich_text', wagtail.wagtailcore.blocks.RichTextBlock()), (b'image', wagtail.wagtailcore.blocks.StructBlock([(b'image', wagtail.wagtailimages.blocks.ImageChooserBlock()), (b'size', wagtail.wagtailcore.blocks.ChoiceBlock(default=b'medium', choices=[(b'tiny', b'Tiny'), (b'small', b'Small'), (b'medium', b'Medium'), (b'large', b'Large'), (b'full_width', b'Full Width')])), (b'layout', wagtail.wagtailcore.blocks.ChoiceBlock(default=b'inline', choices=[(b'img-inline', b'Inline'), (b'img-block', b'Block'), (b'img-left', b'Float Left'), (b'img-right', b'Float Right')]))])), (b'rich_list', wagtail.wagtailcore.blocks.StructBlock([(b'list_content', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock([(b'display_type', wagtail.wagtailcore.blocks.ChoiceBlock(default=b'li_block', choices=[(b'li_block', b'Block'), (b'li_inline', b'Inline'), (b'li_row', b'Row'), (b'li_col', b'Column')])), (b'main_axis', wagtail.wagtailcore.blocks.ChoiceBlock(default=b'm_start', choices=[(b'm_start', b'Start'), (b'm_end', b'End'), (b'm_center', b'Center'), (b'm_space_between', b'Space Between'), (b'm_space_around', b'Space Around')])), (b'perpendicular_axis', wagtail.wagtailcore.blocks.ChoiceBlock(default=b'p_start', choices=[(b'p_start', b'Start'), (b'p_end', b'End'), (b'p_center', b'Center'), (b'p_baseline', b'Baseline'), (b'p_stretch', b'Stretch')])), (b'content', wagtail.wagtailcore.blocks.StreamBlock([(b'rich_text', wagtail.wagtailcore.blocks.RichTextBlock()), (b'image', wagtail.wagtailcore.blocks.StructBlock([(b'image', wagtail.wagtailimages.blocks.ImageChooserBlock()), (b'size', wagtail.wagtailcore.blocks.ChoiceBlock(default=b'medium', choices=[(b'tiny', b'Tiny'), (b'small', b'Small'), (b'medium', b'Medium'), (b'large', b'Large'), (b'full_width', b'Full Width')])), (b'layout', wagtail.wagtailcore.blocks.ChoiceBlock(default=b'inline', choices=[(b'img-inline', b'Inline'), (b'img-block', b'Block'), (b'img-left', b'Float Left'), (b'img-right', b'Float Right')]))]))]))])))]))]),
+            preserve_default=True,
+        ),
+    ]

--- a/revolv/revolv_cms/models.py
+++ b/revolv/revolv_cms/models.py
@@ -8,6 +8,10 @@ from wagtail.wagtailimages.blocks import ImageChooserBlock
 from wagtailsettings import BaseSetting, register_setting
 
 class ImageBlock(blocks.StructBlock):
+    """
+    A block for images whose layout properties and size can be set to one of
+    a small number of useful values.
+    """
     image = ImageChooserBlock()
     size = blocks.ChoiceBlock(choices=[
         ('tiny', 'Tiny'),
@@ -26,6 +30,43 @@ class ImageBlock(blocks.StructBlock):
     class Meta:
         template = 'revolv_cms/blocks/image_block.html'
 
+
+class RichListBlock(blocks.StructBlock):
+    """
+    A list block with rich structure.
+    """
+    list_content = blocks.ListBlock(blocks.StructBlock([
+        # ('centered_row', blocks.BooleanBlock(default=False, required=False)),
+        ('display_type', blocks.ChoiceBlock(choices=[
+            ('li_block', 'Block'),
+            ('li_inline', 'Inline'),
+            ('li_row', 'Row'),
+            ('li_col', 'Column'),
+        ], required=True, default='li_block')),
+        ('main_axis', blocks.ChoiceBlock([
+            ('m_start', 'Start'),
+            ('m_end', 'End'),
+            ('m_center', 'Center'),
+            ('m_space_between', 'Space Between'),
+            ('m_space_around', 'Space Around'),
+        ], required=True, default='m_start')),
+        ('perpendicular_axis', blocks.ChoiceBlock([
+            ('p_start', 'Start'),
+            ('p_end', 'End'),
+            ('p_center', 'Center'),
+            ('p_baseline', 'Baseline'),
+            ('p_stretch', 'Stretch'),
+        ], required=True, default='p_start')),
+        ('content', blocks.StreamBlock([
+            ('rich_text', blocks.RichTextBlock()),
+            ('image', ImageBlock()),
+        ])),
+    ]))
+
+    class Meta:
+        template = 'revolv_cms/blocks/rich_list.html'
+
+
 class RevolvCustomPage(Page):
     """
     A CMS page representing a web page that the RE-volv administrators might
@@ -38,10 +79,10 @@ class RevolvCustomPage(Page):
     can be at any level in the menu hierarchy which we need for both the header
     and footer menus.
     """
-    # body = RichTextField()
     body = StreamField([
         ('rich_text', blocks.RichTextBlock()),
         ('image', ImageBlock()),
+        ('rich_list', RichListBlock()),
     ])
     search_name = "Custom Page"
 

--- a/revolv/revolv_cms/models.py
+++ b/revolv/revolv_cms/models.py
@@ -1,9 +1,29 @@
 from django.db import models
-from wagtail.wagtailadmin.edit_handlers import FieldPanel
+from wagtail.wagtailadmin.edit_handlers import FieldPanel, StreamFieldPanel
 from wagtail.wagtailcore.fields import RichTextField
 from wagtail.wagtailcore.models import Page
+from wagtail.wagtailcore.fields import StreamField
+from wagtail.wagtailcore import blocks
+from wagtail.wagtailimages.blocks import ImageChooserBlock
 from wagtailsettings import BaseSetting, register_setting
 
+class ImageBlock(blocks.StructBlock):
+    image = ImageChooserBlock()
+    size = blocks.ChoiceBlock(choices=[
+        ('tiny', 'Tiny'),
+        ('small', 'Small'),
+        ('medium', 'Medium'),
+        ('large', 'Large'),
+    ], default='medium', required=True)
+    layout = blocks.ChoiceBlock(choices=[
+        ('img-inline', 'Inline'),
+        ('img-block', 'Block'),
+        ('img-left', 'Float Left'),
+        ('img-right', 'Float Right'),
+    ], default='inline', required=True)
+
+    class Meta:
+        template = 'revolv_cms/blocks/image_block.html'
 
 class RevolvCustomPage(Page):
     """
@@ -17,13 +37,17 @@ class RevolvCustomPage(Page):
     can be at any level in the menu hierarchy which we need for both the header
     and footer menus.
     """
-    body = RichTextField()
+    # body = RichTextField()
+    body = StreamField([
+        ('rich_text', blocks.RichTextBlock()),
+        ('image', ImageBlock()),
+    ])
     search_name = "Custom Page"
 
     indexed_fields = ('body', )
     content_panels = [
         FieldPanel('title', classname="full title"),
-        FieldPanel('body', classname="full"),
+        StreamFieldPanel('body'),
     ]
 
 
@@ -460,4 +484,3 @@ class ShareThisSettings(BaseSetting):
     """
     image = models.URLField(verbose_name='Image Url', help_text='The Url of image that will be used in ShareThis widget')
     description = models.CharField(max_length=200, help_text="The description that will be used in ShareThis widget")
-

--- a/revolv/revolv_cms/models.py
+++ b/revolv/revolv_cms/models.py
@@ -14,6 +14,7 @@ class ImageBlock(blocks.StructBlock):
         ('small', 'Small'),
         ('medium', 'Medium'),
         ('large', 'Large'),
+        ('full_width', 'Full Width'),
     ], default='medium', required=True)
     layout = blocks.ChoiceBlock(choices=[
         ('img-inline', 'Inline'),

--- a/revolv/static/cms-page.scss
+++ b/revolv/static/cms-page.scss
@@ -4,6 +4,10 @@
     margin-top: 50px;
     margin-bottom: 50px;
     font-weight: 400;
+    -webkit-box-flex: 1;
+    -webkit-flex: 1 0 auto;
+        -ms-flex: 1 0 auto;
+            flex: 1 0 auto;
 
     img {
         padding: 10px 20px;

--- a/revolv/static/cms-page.scss
+++ b/revolv/static/cms-page.scss
@@ -80,4 +80,21 @@
             font-weight: 400;
         }
     }
+
+    img {
+        &.img-inline {
+            display: inline;
+        }
+        &.img-block {
+            display: block;
+        }
+        &.img-left {
+            display: block;
+            float: left;
+        }
+        &.img-right {
+            display: block;
+            float: right;
+        }
+    }
 }

--- a/revolv/static/cms-page.scss
+++ b/revolv/static/cms-page.scss
@@ -1,62 +1,83 @@
 @import "revolv-settings";
 
-.cms-content-row {
-    margin-top: 50px;
-    margin-bottom: 50px;
-    font-weight: 400;
+.cms-content-container {
     -webkit-box-flex: 1;
     -webkit-flex: 1 0 auto;
         -ms-flex: 1 0 auto;
             flex: 1 0 auto;
+    margin-top: 102px;
 
-    img {
-        padding: 10px 20px;
-
-        &.left {
-            padding-left: 0;
-        }
-        &.right {
-            padding-right: 0;
-        }
+    @media (max-width: 1199px) {
+        margin-top: 85px;
+        width: 100%;
+        max-width: 970px;
     }
-
-    h1, h2, h3, h4, h5, h6 {
-        margin-bottom: 20px;
-        font-weight: bold;
+    @media (max-width: 991px) {
+        margin-top: 185px;
+    }
+    @media (max-width: 767px) {
+        margin-top: 92.5px;
     }
 
-    h1 {
-        font-size: 32px;
-        line-height: 36px;
-        color: $revolv-dark-blue;
-    }
-
-    h2, h3, h4, h5, h6 {
-        color: $revolv-blue;
-    }
-    h2 {
-        font-size: 28px;
-        line-height: 30px;
-    }
-    h3 {
-        font-size: 24px;
-        line-height: 28px;
-    }
-    h4 {
-        font-size: 20px;
-        line-height: 24px;
-    }
-    h5 {
-        font-size: 18px;
-        line-height: 20px;
-    }
-    h6 {
-        font-size: 28px;
-        line-height: 30px;
-    }
-
-    p {
-        max-width: 800px;
+    .cms-content-row {
         font-weight: 400;
+
+        padding: 15px 0;
+
+        > .columns {
+            max-width: 960px;
+            margin: 0 auto;
+        }
+
+        img {
+            padding: 10px 20px;
+
+            &.left {
+                padding-left: 0;
+            }
+            &.right {
+                padding-right: 0;
+            }
+        }
+
+        h1, h2, h3, h4, h5, h6 {
+            margin-bottom: 20px;
+            font-weight: bold;
+        }
+
+        h1 {
+            font-size: 32px;
+            line-height: 36px;
+            color: $revolv-dark-blue;
+        }
+
+        h2, h3, h4, h5, h6 {
+            color: $revolv-blue;
+        }
+        h2 {
+            font-size: 28px;
+            line-height: 30px;
+        }
+        h3 {
+            font-size: 24px;
+            line-height: 28px;
+        }
+        h4 {
+            font-size: 20px;
+            line-height: 24px;
+        }
+        h5 {
+            font-size: 18px;
+            line-height: 20px;
+        }
+        h6 {
+            font-size: 28px;
+            line-height: 30px;
+        }
+
+        p {
+            max-width: 800px;
+            font-weight: 400;
+        }
     }
 }

--- a/revolv/static/cms-page.scss
+++ b/revolv/static/cms-page.scss
@@ -30,7 +30,8 @@
         }
 
         img {
-            padding: 10px 20px;
+            padding: 0 20px;
+            box-sizing: content-box;
 
             &.left {
                 padding-left: 0;
@@ -79,6 +80,106 @@
             max-width: 800px;
             font-weight: 400;
         }
+
+        ul {
+            li {
+                margin-bottom: 15px;
+                &:last-child {
+                    margin-bottom: 0;
+                }
+
+                &.li_block {
+                    display: block;
+                }
+                &.li_inline {
+                    display: inline;
+                }
+                &.li_row, &.li_col {
+                    display: -webkit-box;
+                    display: -webkit-flex;
+                    display: -ms-flexbox;
+                    display: flex;
+
+                    &.m_start {
+                        -webkit-box-pack: start;
+                        -webkit-justify-content: flex-start;
+                            -ms-flex-pack: start;
+                                justify-content: flex-start;
+                    }
+                    &.m_end {
+                        -webkit-box-pack: end;
+                        -webkit-justify-content: flex-end;
+                            -ms-flex-pack: end;
+                                justify-content: flex-end;
+                    }
+                    &.m_center {
+                        -webkit-box-pack: center;
+                        -webkit-justify-content: center;
+                            -ms-flex-pack: center;
+                                justify-content: center;
+                    }
+                    &.m_space_between {
+                        -webkit-box-pack: justify;
+                        -webkit-justify-content: space-between;
+                            -ms-flex-pack: justify;
+                                justify-content: space-between;
+                    }
+                    &.m_space_around {
+                        -webkit-justify-content: space-around;
+                            -ms-flex-pack: distribute;
+                                justify-content: space-around;
+                    }
+
+                    &.p_start {
+                        -webkit-box-align: start;
+                        -webkit-align-items: flex-start;
+                            -ms-flex-align: start;
+                                align-items: flex-start;
+                    }
+                    &.p_end {
+                        -webkit-box-align: end;
+                        -webkit-align-items: flex-end;
+                            -ms-flex-align: end;
+                                align-items: flex-end;
+                    }
+                    &.p_center {
+                        -webkit-box-align: center;
+                        -webkit-align-items: center;
+                            -ms-flex-align: center;
+                                align-items: center;
+                    }
+                    &.p_baseline {
+                        -webkit-box-align: baseline;
+                        -webkit-align-items: baseline;
+                            -ms-flex-align: baseline;
+                                align-items: baseline;
+                    }
+                    &.p_stretch {
+                        -webkit-box-align: stretch;
+                        -webkit-align-items: stretch;
+                            -ms-flex-align: stretch;
+                                align-items: stretch;
+                    }
+                }
+                &.li_row {
+                    -webkit-box-orient: horizontal;
+                    -webkit-box-direction: normal;
+                    -webkit-flex-direction: row;
+                        -ms-flex-direction: row;
+                            flex-direction: row;
+                    -webkit-flex-wrap: nowrap;
+                        -ms-flex-wrap: nowrap;
+                            flex-wrap: nowrap;
+                }
+                &.li_col {
+                    -webkit-box-orient: vertical;
+                    -webkit-box-direction: normal;
+                    -webkit-flex-direction: col;
+                        -ms-flex-direction: col;
+                            flex-direction: col;
+                }
+            }
+        }
     }
 
     img {
@@ -98,6 +199,7 @@
         }
         &.full-width {
             width: 100% !important;
+            height: auto !important;
             display: block !important;
             float: none !important;
         }

--- a/revolv/static/cms-page.scss
+++ b/revolv/static/cms-page.scss
@@ -96,5 +96,10 @@
             display: block;
             float: right;
         }
+        &.full-width {
+            width: 100% !important;
+            display: block !important;
+            float: none !important;
+        }
     }
 }

--- a/revolv/static/css/screen.css
+++ b/revolv/static/css/screen.css
@@ -95,6 +95,16 @@ html {
 /* common style */
 body {
 	background: #fff;
+	display: -webkit-box;
+	display: -webkit-flex;
+	display: -ms-flexbox;
+	display: flex;
+	min-height: 100vh;
+	-webkit-box-orient: vertical;
+	-webkit-box-direction: normal;
+	-webkit-flex-direction: column;
+	    -ms-flex-direction: column;
+	        flex-direction: column;
 }
 input,
 button {
@@ -170,8 +180,8 @@ a:focus {
 			.btn-icon-gray:hover .icon-gg {
 				background-position: -264px -16px;
 			}
-			
-			
+
+
 /* title */
 .title-white-border,
 .title-blue-border {
@@ -227,8 +237,8 @@ a:focus {
 			right: 9px;
 			z-index: 9;
 		}
-		.dropdown-default .btn-default.active, 
-		.dropdown-default .btn-default:active, 
+		.dropdown-default .btn-default.active,
+		.dropdown-default .btn-default:active,
 		.open.dropdown-default>.dropdown-toggle.btn-default {
 			color: #9d9d9d;
 			background-color: #f0f0f0;
@@ -269,7 +279,7 @@ a:focus {
 				background-image: none;
 				filter: none;
 			}
-    
+
 
 
 
@@ -286,7 +296,7 @@ a:focus {
 	.header .container {
 		height: 100%;
 		padding: 0;
-	} 
+	}
 		.header .logo {
 			background: url(../images/logo-white.png);
 			margin: 17px 0 0 85px;
@@ -1082,12 +1092,12 @@ a:focus {
 							background: url(../images/logo-ehe-new-hork-eimes.png) no-repeat;
 							width: 137px;
 							height: 113px;
-						} 
+						}
 						.featured-on-module .logo-shareable {
 							background: url(../images/logo-shareable.png) no-repeat;
 							width: 144px;
 							height: 21px;
-						} 
+						}
 						.featured-on-module .logo-philanthropy {
 							background: url(../images/logo-philanthropy.png) no-repeat;
 							width: 153px;
@@ -1098,7 +1108,7 @@ a:focus {
 							width: 153px;
 							height: 44px;
 							margin-bottom: 25px;
-						} 
+						}
 							.featured-on-module .logo-fast-mpany:hover,
 							.featured-on-module .logo-fast-mpany:focus,
 							.featured-on-module .logo-ehe-new-hork-eimes:hover,
@@ -1268,7 +1278,7 @@ a:focus {
     .top100 {
 		margin-top: 100px;
 	}
-	
+
 	/* .titles */
 	.titles.container {
 		padding: 43px 0 0 0;
@@ -1287,8 +1297,8 @@ a:focus {
 			color: #2c3691;
 			line-height: 56px;
 		}
-		
-		
+
+
 	/* sign in page */
 	.contents.sign-in-contents {
 		min-height: 508px;
@@ -1309,15 +1319,15 @@ a:focus {
 			float: left;
 			padding-top: 71px;
 		}
-			.sign-in .sign-in-left h2 {				
+			.sign-in .sign-in-left h2 {
 				font-family: 'Source Sans Pro';
                 font-weight: 900;
 				font-size: 48px;
 				line-height: 52px;
 				color: #2e3192;
-				margin-bottom: 9px;				
+				margin-bottom: 9px;
 			}
-			.sign-in .sign-in-left p {			
+			.sign-in .sign-in-left p {
 				font-size: 14px;
 				line-height: 24px;
 				color: #4b4b4b;
@@ -1328,7 +1338,7 @@ a:focus {
 			}
 			.sign-in .sign-in-left .account {
 				margin-top: 27px;
-			} 
+			}
 			.sign-in .sign-in-left a {
 				font-size: 14px;
 				line-height: 20px;
@@ -1375,8 +1385,8 @@ a:focus {
 					line-height: 43px;
 					letter-spacing: 4px;
 				}
-		
-		
+
+
 	/* sign up page */
 	.contents.sign-up-contents {
 		min-height: 851px;
@@ -1398,15 +1408,15 @@ a:focus {
 			float: left;
 			padding-top: 76px;
 		}
-			.sign-up .sign-up-left h2 {				
+			.sign-up .sign-up-left h2 {
 				font-family: 'Source Sans Pro';
                 font-weight: 900;
 				font-size: 48px;
 				line-height: 52px;
 				color: #2e3192;
-				margin-bottom: 4px;				
+				margin-bottom: 4px;
 			}
-			.sign-up .sign-up-left p {			
+			.sign-up .sign-up-left p {
 				font-size: 14px;
 				line-height: 28px;
 				color: #4b4b4b;
@@ -1417,7 +1427,7 @@ a:focus {
 			}
 			.sign-up .sign-up-left .account {
 				margin-top: 27px;
-			} 
+			}
 			.sign-up .sign-up-left a {
 				font-size: 14px;
 				line-height: 28px;
@@ -1482,8 +1492,8 @@ a:focus {
 					line-height: 43px;
 					letter-spacing: 4px;
 				}
-		
-		
+
+
 	/* what do page */
 	.contents.what-we-do-contents {
 		min-height: 1000px;
@@ -1563,8 +1573,8 @@ a:focus {
 					padding-left: 32px;
 					padding-right: 33px;
 				}
-		
-		
+
+
 	/* about us page */
 	.contents.about-us-contents {
 		min-height: 600px;
@@ -1632,7 +1642,7 @@ a:focus {
 				text-decoration: none;
 				text-align: center;
 			}
-			.mains-tabs .tab-index .row .col-lg-3 a:hover,			
+			.mains-tabs .tab-index .row .col-lg-3 a:hover,
 			.mains-tabs .tab-index .row .col-lg-3 a.active {
 				border-top: 4px solid #00a1d9;
 				color: #4b4b4b;
@@ -1707,10 +1717,10 @@ a:focus {
 						height: 43px;
 						letter-spacing: 4px;
 					}
-	
+
 
 	/* get involved page */
-	
+
 		/* .info-area */
 		.info-area.container {
 			padding: 0 83px 35px 83px;
@@ -1725,7 +1735,7 @@ a:focus {
 				padding-right: 430px;
 				padding-bottom: 17px;
 			}
-					
+
 		/* .list-area */
 		.list-area.container {
 			padding: 0 83px 40px 83px;
@@ -1875,7 +1885,7 @@ a:focus {
 								float: left;
 								margin-left: 12px;
 							}
-					
+
 		/* .past-projects-module */
 		.past-projects-module {
 			background-color: #ededed;
@@ -2041,7 +2051,7 @@ a:focus {
 														.past-projects-module .carousel-control:hover.right .icons {
 															background-position: -384px -16px;
 														}
-	
+
 
 	/* project details page */
 	.details-active-project-module {
@@ -2116,8 +2126,8 @@ a:focus {
 								font-size: 58.26px !important;
 								margin-top: 50px !important;
 							}
-						
-						
+
+
 				/* .details-active-project-module .info-section */
 				.details-active-project-module .info-section {
 					position: relative;
@@ -2235,7 +2245,7 @@ a:focus {
 										font-size: 14px;
 										line-height: 24px;
 									}
-				    
+
 		/* .project-updates-module */
 		.project-updates-module {
 			position: relative;
@@ -2402,7 +2412,7 @@ a:focus {
 									 color: #8a8a8a;
 									 display: block;
 								 }
-				    
+
 		/* .donors-module */
 		.donors-module {
 			position: relative;
@@ -2467,9 +2477,9 @@ a:focus {
 						line-height: 28px;
 						padding: 0 25px 0 0;
 					}
-					
-					
-					
+
+
+
 	/* partners page */
 	.contents.partners-contents {
 		position: relative;
@@ -2482,7 +2492,7 @@ a:focus {
 			padding-right: 22px;
 			margin-right: 83px;
 			margin-bottom: 34px;
-		} 
+		}
 			.partners-contents .titles .title-primary {
 				font-family: 'Source Sans Pro'; font-weight: 900;
 				font-size: 48px;
@@ -2546,7 +2556,7 @@ a:focus {
 					color: #4b4b4b;
 					padding-right: 405px;
 					padding-left: 2px;
-				}			
+				}
 			.partners-contents .btn-wrap {
 				margin: 0 0 0 231px;
 				min-height: 43px;
@@ -2581,7 +2591,7 @@ a:focus {
 					.partners-contents .pager-info li a:hover {
 						background-color: #c3c1c1;
 					}
-				    
+
 		/* .sponsoring-organizations-module */
 		.sponsoring-organizations-module {
 			background: #f4f4f4;
@@ -2684,9 +2694,9 @@ a:focus {
 									.sponsoring-organizations-module .carousel-control:hover.right .icons {
 										background-position: -384px -16px;
 									}
-				
-				
-				
+
+
+
 	/* solar ambassador program page */
 	.contents.solar-ambassador-program-contents {
 		min-height: 1000px;
@@ -2737,19 +2747,19 @@ a:focus {
 					padding-left: 41px;
 					padding-right: 39px;
 				}
-				
-					
-	
+
+
+
 
 	/* blog page */
-	
+
 		.titles.container .title-blog {
 			margin-right: 83px;
 			min-width: 133px;
 			letter-spacing: 9px;
 			padding-left: 20px;
 		}
-		
+
 		/* .grid-data */
 		.grid-data.container {
 			padding: 0 68px;
@@ -2951,7 +2961,7 @@ a:focus {
 								float: left;
 								margin: 0 6px 0 7px;
 							}
-		
+
 		/* .loading-bar */
 		.loading-bar {
 			text-align: center;
@@ -2963,8 +2973,8 @@ a:focus {
 				height: 22px;
 				display: block;
 				margin: 0 auto;
-			}						
-					
+			}
+
 			/* .blog-details-data */
 			.blog-details-data.container {
 				padding: 0 83px;
@@ -3032,8 +3042,8 @@ a:focus {
 							}
 							.blog-details-data.container .info-box .info-main .rights .down25 {
 								padding-bottom: 27px;
-							}					
-					
+							}
+
 			/* .related-blog-module */
 			.related-blog-module {
 				padding: 26px 0 7px 0;
@@ -3096,7 +3106,7 @@ a:focus {
 						.related-blog-module .carousel-inner>.active {
 							min-height: 620px;
 						}
-				    
+
 		/* .comments-module */
 		.comments-module {
 			background: #f4f4f4;
@@ -3187,7 +3197,7 @@ a:focus {
 				/* .comments-module .comments-area .quick-reply */
 				.comments-module .comments-area .quick-reply {
 					padding: 38px 0 121px 0;
-					position: relative;	
+					position: relative;
 				}
 					.comments-module .comments-area .quick-reply .quick-reply-txt {
 						float: left;
@@ -3276,7 +3286,7 @@ a:focus {
 		top: 0;
 		left: 0;
 		z-index: 99;
-	} 
+	}
 	/* .footer .row */
 	.footer .row {
 		margin: 0;
@@ -3381,7 +3391,7 @@ a:focus {
 .modal.modal-default .modal-dialog {
 	width: 1170px;
 	margin: 109px auto;
-}	
+}
 	.modal.modal-default .modal-content {
 		-webkit-box-shadow: 0 0 40px rgba(34,34,33,.9);
 		box-shadow: 0 0 40px rgba(34,34,33,.9);
@@ -3526,7 +3536,7 @@ a:focus {
 @media (min-width: 1221px) {
 .container {
     width: 1200px;
-} 
+}
 }
 
 
@@ -3590,8 +3600,8 @@ a:focus {
 			top: 6px;
 			right: 7px;
 		}
-			.dropdown-default .btn-default.active .icon-arrow-down, 
-			.dropdown-default .btn-default:active .icon-arrow-down, 
+			.dropdown-default .btn-default.active .icon-arrow-down,
+			.dropdown-default .btn-default:active .icon-arrow-down,
 			.open.dropdown-default>.dropdown-toggle.btn-default .icon-arrow-down {
 				background-position: -52px 0;
 			}
@@ -3613,11 +3623,11 @@ a:focus {
 	line-height: 35px;
 	padding: 0 5px;
 }
-			
-			
+
+
 .container {
 	width: auto;
-} 
+}
 
 
 /* .header */
@@ -4088,12 +4098,12 @@ a:focus {
 						background-size: 115.5px auto;
 						width: 116px;
 						height: 96px;
-					} 
+					}
 					.featured-on-module .logo-shareable {
 						background-size: 119px auto;
 						width: 119px;
 						height: 17px;
-					} 
+					}
 						.featured-on-module .logo-shareable:hover,
 						.featured-on-module .logo-shareable:focus {
 							background-position: center -16px;
@@ -4108,7 +4118,7 @@ a:focus {
 						width: 126px;
 						height: 37px;
 						margin-bottom: 13px;
-					} 
+					}
 						.featured-on-module .logo-clean-technica:hover,
 						.featured-on-module .logo-clean-technica:focus {
 							background-position: center -36.5px;
@@ -4212,7 +4222,7 @@ a:focus {
 .top150 {
 	margin-top: 124px;
 }
-	
+
 	/* .titles */
 	.titles.container {
 		padding: 35px 0 0 0;
@@ -4228,7 +4238,7 @@ a:focus {
 			font-size: 39.68px;
 			line-height: 48px;
 		}
-	
+
 
 	/* sign in page */
 	.contents.sign-in-contents {
@@ -4250,18 +4260,18 @@ a:focus {
 		.sign-in .sign-in-left {
 			padding-top: 56px;
 		}
-			.sign-in .sign-in-left h2 {				
+			.sign-in .sign-in-left h2 {
 				font-size: 40px;
 				line-height: 48px;
-				margin-bottom: 7px;				
+				margin-bottom: 7px;
 			}
-			.sign-in .sign-in-left p {			
+			.sign-in .sign-in-left p {
 				font-size: 12px;
 				line-height: 20px;
 			}
 			.sign-in .sign-in-left .account {
 				margin-top: 19px;
-			} 
+			}
 			.sign-in .sign-in-left a {
 				font-size: 12px;
 				line-height: 20px;
@@ -4293,7 +4303,7 @@ a:focus {
 					font-size: 12px;
 					letter-spacing: 2px;
 				}
-	
+
 
 	/* sign up page */
 	.contents.sign-up-contents {
@@ -4315,18 +4325,18 @@ a:focus {
 		.sign-up .sign-up-left {
 			padding-top: 61px;
 		}
-			.sign-up .sign-up-left h2 {			
+			.sign-up .sign-up-left h2 {
 				font-size: 40px;
 				line-height: 48px;
-				margin-bottom: 1px;				
+				margin-bottom: 1px;
 			}
-			.sign-up .sign-up-left p {			
+			.sign-up .sign-up-left p {
 				font-size: 12px;
 				line-height: 23px;
 			}
 			.sign-up .sign-up-left .account {
 				margin-top: 23px;
-			} 
+			}
 			.sign-up .sign-up-left a {
 				font-size: 12px;
 				line-height: 23px;
@@ -4369,7 +4379,7 @@ a:focus {
 					line-height: 36px;
 					letter-spacing: 3px;
 				}
-	
+
 
 	/* what do page */
 	.contents.what-we-do-contents {
@@ -4437,7 +4447,7 @@ a:focus {
 					padding-left: 27px;
 					padding-right: 29px;
 				}
-	
+
 
 	/* about us page */
 	.contents.about-us-contents {
@@ -4534,10 +4544,10 @@ a:focus {
 						height: 36px;
 						letter-spacing: 3px;
 					}
-	
+
 
 	/* get involved page */
-	
+
 		/* .info-area */
 		.info-area.container {
 			padding: 0 69px 35px 69px;
@@ -4551,7 +4561,7 @@ a:focus {
 				padding-right: 340px;
 				padding-bottom: 17px;
 			}
-					
+
 		/* .list-area */
 		.list-area.container {
 			padding: 0 69px 34px 69px;
@@ -4631,7 +4641,7 @@ a:focus {
 								float: left;
 								margin-left: 12px;
 							}
-					
+
 		/* .past-projects-module */
 		.past-projects-module {
 			padding-bottom: 45px;
@@ -4721,7 +4731,7 @@ a:focus {
 												.past-projects-module .carousel-control:hover.right .icons {
 													background-position: -310px -13px;
 												}
-	
+
 
 		/* project details page */
 		.details-active-project-module .banners.min-height455 {
@@ -4818,7 +4828,7 @@ a:focus {
 										font-size: 11.57px;
 										line-height: 20px;
 									}
-				    
+
 		/* .project-updates-module */
 		.project-updates-module .container {
 			padding: 38px 39px 20px 92px;
@@ -4948,7 +4958,7 @@ a:focus {
 								 .project-updates-module .main-area .venue-bottom p span {
 									 font-size: 11.57px;
 								 }
-				    
+
 			/* .donors-module */
 			.donors-module .titles.container {
 				padding: 0;
@@ -4988,11 +4998,11 @@ a:focus {
 						line-height: 23px;
 						padding: 0 15px 0 0;
 						margin-top: -2px;
-					}							
-					
-					
-					
-					
+					}
+
+
+
+
 	/* partners page */
 	.partners-contents .container {
 		padding: 35px 0 37px 70px;
@@ -5005,7 +5015,7 @@ a:focus {
 		padding-right: 16px;
 		margin-right: 68px;
 		margin-bottom: 25px;
-	} 
+	}
 		.partners-contents .titles .title-primary {
 			font-size: 40px;
 			line-height: 46px;
@@ -5015,7 +5025,7 @@ a:focus {
 			font-size: 12px;
 			line-height: 24px;
 		}
-	
+
 		/* .partners-contents .list */
 		.partners-contents .list-wrap {
 			margin-top: 41px;
@@ -5055,7 +5065,7 @@ a:focus {
 					line-height: 23px;
 					padding-right: 350px;
 					padding-left: 2px;
-				}			
+				}
 			.partners-contents .btn-wrap {
 				margin: 0 0 0 191px;
 			}
@@ -5078,8 +5088,8 @@ a:focus {
 						font-size: 13px;
 						line-height: 32px;
 						height: 32px;
-					}	
-				    
+					}
+
 		/* .sponsoring-organizations-module */
 		.sponsoring-organizations-module {
 			min-height: 320px;
@@ -5151,10 +5161,10 @@ a:focus {
 											  .sponsoring-organizations-module .carousel-control:hover.right .icons {
 												  background-position: -310px -13px;
 											  }
-				
-				
-				
-				
+
+
+
+
 	/* solar ambassador program page */
 	.solar-contents .article-detail {
 		padding: 35px 41px 62px 71px;
@@ -5196,9 +5206,9 @@ a:focus {
 				padding-left: 33px;
 				padding-right: 36px;
 			}
-				
-					
-	
+
+
+
 
 	/* blog page */
 	.titles.container .title-blog {
@@ -5207,7 +5217,7 @@ a:focus {
 		letter-spacing: 8px;
 		padding-left: 12px;
 	}
-	
+
 	/* .grid-data */
 	.grid-data.container {
 		padding: 0 55px;
@@ -5343,7 +5353,7 @@ a:focus {
 						.grid-area.row .info-main .bottom-bar .social-ul li {
 							margin: 0 5px 0 6px;
 						}
-	
+
 	/* .loading-bar */
 	.loading-bar {
 		padding: 0 0 58px 0;
@@ -5352,8 +5362,8 @@ a:focus {
 			background-size: 106px auto;
 			width: 106px;
 			height: 18px;
-		}						
-				
+		}
+
 		/* .blog-details-data */
 		.blog-details-data.container {
 			padding: 0 68px;
@@ -5400,8 +5410,8 @@ a:focus {
 					}
 					.blog-details-data.container .info-box .info-main .rights .down25 {
 						padding-bottom: 20px;
-					}					
-				
+					}
+
 		/* .related-blog-module */
 		.related-blog-module {
 			padding: 20px 0 7px 0;
@@ -5447,7 +5457,7 @@ a:focus {
 					.related-blog-module .carousel-inner>.active {
 						min-height: 512px;
 					}
-				
+
 		/* .comments-module */
 		.comments-module .container {
 			padding: 30px 68px 0 68px;
@@ -5554,9 +5564,9 @@ a:focus {
 						padding: 2px 0 0 3px;
 
 					}
-							
-							
-	
+
+
+
 /* .footer */
 .footer .row {
 	padding: 0 82px 0 95px;
@@ -5635,7 +5645,7 @@ a:focus {
 .modal.modal-default .modal-dialog {
 	width: 967px;
 	margin: 90px auto;
-}	
+}
 	/* .modal-default .modal-header */
 	.modal.modal-default .modal-header {
 		text-align: center;
@@ -5732,7 +5742,7 @@ a:focus {
 							  line-height: 21px;
 						  }
 }
-						
+
 
 
 
@@ -5791,8 +5801,8 @@ a:focus {
 			top: 16px;
 			right: 17px;
 		}
-			.dropdown-default .btn-default.active .icon-arrow-down, 
-			.dropdown-default .btn-default:active .icon-arrow-down, 
+			.dropdown-default .btn-default.active .icon-arrow-down,
+			.dropdown-default .btn-default:active .icon-arrow-down,
 			.open.dropdown-default>.dropdown-toggle.btn-default .icon-arrow-down {
 				background-position: -113px 0;
 			}
@@ -5805,9 +5815,9 @@ a:focus {
 				padding: 0 25px;
 				line-height: 26px;
 			}
-			
-			
-			
+
+
+
 /* title */
 .title-white-border,
 .title-blue-border {
@@ -6035,8 +6045,8 @@ a:focus {
 						.mobile-circle {
 							display: none;
 						}
-						
-	
+
+
 					/* .active-projects-module .info-main */
 					.active-projects-module .info-main {
 						padding: 86px 61px 34px 58px;
@@ -6196,8 +6206,8 @@ a:focus {
 				margin-right: 85px;
 				margin-left: 85px;
 			}
-				.how-it-works-module .row .carousel-control, 
-				.how-it-works-module .row .carousel-control .icons, 
+				.how-it-works-module .row .carousel-control,
+				.how-it-works-module .row .carousel-control .icons,
 				.how-it-works-module .row .carousel-indicators {
 					display: block;
 				}
@@ -6205,8 +6215,8 @@ a:focus {
 						float: none;
 						display: none;
 					}
-					.how-it-works-module .step-row .carousel-inner>.active, 
-					.how-it-works-module .step-row .carousel-inner>.next, 
+					.how-it-works-module .step-row .carousel-inner>.active,
+					.how-it-works-module .step-row .carousel-inner>.next,
 					.how-it-works-module .step-row .carousel-inner>.prev {
 						display: block;
 					}
@@ -6274,7 +6284,7 @@ a:focus {
 								width: 18px;
 								height: 18px;
 								background-color: rgba(41,41,41,1);
-							}	
+							}
 								.how-it-works-module .step-row .module-box {
 									padding: 10px 33px 0 33px;
 									min-height: 170px;
@@ -6447,12 +6457,12 @@ a:focus {
 							background-size: 137px auto;
 							width: 137px;
 							height: 113px;
-						} 
+						}
 						.featured-on-module .logo-shareable {
 							background-size: 144px auto;
 							width: 144px;
 							height: 21px;
-						} 
+						}
 						.featured-on-module .logo-philanthropy {
 							background-size: 153px auto;
 							width: 153px;
@@ -6462,7 +6472,7 @@ a:focus {
 							background-size: 153px auto;
 							width: 153px;
 							height: 44px;
-						} 
+						}
 							.featured-on-module .logo-fast-mpany:hover,
 							.featured-on-module .logo-fast-mpany:focus,
 							.featured-on-module .logo-ehe-new-hork-eimes:hover,
@@ -6505,8 +6515,8 @@ a:focus {
 							.featured-on-module .carousel-control:hover.right .icons {
 								background-position: -384px -16px;
 							}
-			
-			
+
+
 
 	/* .newsletter-module */
 	.newsletter-module {
@@ -6575,7 +6585,7 @@ a:focus {
 	.top150 {
 		margin-top: 185px;
 	}
-	
+
 	/* .titles */
 	.titles.container {
 		padding: 52px 0 0 0;
@@ -6591,7 +6601,7 @@ a:focus {
 			font-size: 49.15px;
 			line-height: 60px;
 		}
-	
+
 
 	/* sign in page */
 	.contents.sign-in-contents {
@@ -6614,18 +6624,18 @@ a:focus {
 			float: none;
 			padding-top: 92px;
 		}
-			.sign-in .sign-in-left h2 {				
+			.sign-in .sign-in-left h2 {
 				font-size: 48px;
 				line-height: 52px;
-				margin-bottom: 11px;				
+				margin-bottom: 11px;
 			}
-			.sign-in .sign-in-left p {			
+			.sign-in .sign-in-left p {
 				font-size: 16px;
 				line-height: 32px;
 			}
 			.sign-in .sign-in-left .account {
 				margin-top: 32px;
-			} 
+			}
 			.sign-in .sign-in-left a {
 				font-size: 16px;
 				line-height: 32px;
@@ -6657,7 +6667,7 @@ a:focus {
 					letter-spacing: 4px;
 					font-size: 14px;
 				}
-	
+
 
 	/* sign up page */
 	.contents.sign-up-contents {
@@ -6679,18 +6689,18 @@ a:focus {
 			float: none;
 			padding-top: 82px;
 		}
-			.sign-up .sign-up-left h2 {				
+			.sign-up .sign-up-left h2 {
 				font-size: 48px;
 				line-height: 52px;
-				margin-bottom: 11px;				
+				margin-bottom: 11px;
 			}
-			.sign-up .sign-up-left p {			
+			.sign-up .sign-up-left p {
 				font-size: 16px;
 				line-height: 32px;
 			}
 			.sign-up .sign-up-left .account {
 				margin-top: 32px;
-			} 
+			}
 			.sign-up .sign-up-left a {
 				font-size: 16px;
 				line-height: 32px;
@@ -6733,7 +6743,7 @@ a:focus {
 					line-height: 47px;
 					letter-spacing: 4px;
 				}
-	
+
 
 	/* what do page */
 	.contents.what-we-do-contents {
@@ -6802,7 +6812,7 @@ a:focus {
 					padding-left: 39px;
 					padding-right: 36px;
 				}
-	
+
 
 	/* about us page */
 	.contents.about-us-contents {
@@ -6904,10 +6914,10 @@ a:focus {
 					.mains-tabs .tab-content .tab-funded .content-right p {
 						margin-bottom: 30px;
 						padding-right: 35px;
-					}				
+					}
 				.mains-tabs .tab-content .tab-funded .content-right  {
 					padding-top: 40px;
-				}					
+				}
 					.mains-tabs .tab-content .tab-funded .content-right p {
 						padding-right: 35px;
 						padding-top: 2px;
@@ -6929,10 +6939,10 @@ a:focus {
 					.mains-tabs .tab-content .tab-involved .btn-blue:nth-child(2n) {
 						float: right;
 					}
-					
-	
+
+
 	/* get involved page */
-	
+
 		/* .info-area */
 		.info-area.container {
 			padding: 0 30px 35px 60px;
@@ -6946,7 +6956,7 @@ a:focus {
 				padding-right: 70px;
 				padding-bottom: 17px;
 			}
-					
+
 		/* .list-area */
 		.list-area.container {
 			background: #ededed;
@@ -7072,7 +7082,7 @@ a:focus {
 								margin-left: 0;
 								margin-right: 18px;
 							}
-					
+
 		/* .past-projects-module */
 		.past-projects-module {
 			background-color: #fff;
@@ -7176,7 +7186,7 @@ a:focus {
 													.past-projects-module .carousel-control:hover.right .icons {
 														background-position: -384px -16px;
 													}
-	
+
 
 	/* project details page */
 	.details-active-project-module .banners.min-height455 {
@@ -7309,7 +7319,7 @@ a:focus {
 										margin-left: -10px;
 										display: block;
 									}
-							
+
 							.details-active-project-module .txt-area .txt-td {
 								line-height: 20px;
 							}
@@ -7323,7 +7333,7 @@ a:focus {
 									font-size: 16.38px;
 									line-height: 32px;
 								}
-				    
+
 			/* .project-updates-module */
 			.project-updates-module .container {
 				padding: 57px 31px 20px 31px;
@@ -7424,7 +7434,7 @@ a:focus {
 												.project-updates-module .list-area .main-info .btn-icon-gray:hover .icon-gg {
 													background-position: -264px -16px;
 												}
-								 
+
 				/* .project-updates-module .right-aside */
 				.project-updates-module .right-aside {
 					width: 100%;
@@ -7495,7 +7505,7 @@ a:focus {
 					 .project-updates-module .venue-area {
 						 display: none;
 					 }
-				    
+
 			/* .donors-module */
 			.donors-module .titles.container {
 				text-align: center;
@@ -7555,8 +7565,8 @@ a:focus {
 						line-height: 35px;
 						padding: 0 45px 0 0;
 					}
-								
-					
+
+
 	/* partners page */
 	.partners-contents .container {
 		padding: 50px 0 11px 42px;
@@ -7570,7 +7580,7 @@ a:focus {
 		margin-right: 39px;
 		margin-bottom: 40px;
 		letter-spacing: 8px;
-	} 
+	}
 		.partners-contents .titles .title-primary {
 			font-size: 48px;
 			line-height: 52px;
@@ -7619,7 +7629,7 @@ a:focus {
 					line-height: 32px;
 					padding-right: 41px;
 					padding-left: 2px;
-				}			
+				}
 			.partners-contents .btn-wrap {
 				position: absolute;
 				top: 205px;
@@ -7630,7 +7640,7 @@ a:focus {
 					line-height: 43px;
 					padding-left: 48px;
 					padding-right: 44px;
-				}	
+				}
 			/* .partners-contents .pager-info */
 			.partners-contents .pager-info {
 				margin-top: 23px;
@@ -7647,7 +7657,7 @@ a:focus {
 						line-height: 39px;
 						height: 39px;
 					}
-				    
+
 		/* .sponsoring-organizations-module */
 		.sponsoring-organizations-module {
 			min-height: 450px;
@@ -7744,10 +7754,10 @@ a:focus {
 								.sponsoring-organizations-module .carousel-control:hover.right .icons {
 									background-position: -384px -16px;
 								}
-				
-				
-				
-					
+
+
+
+
 	/* solar ambassador program page */
 	.solar-contents .article-detail {
 		padding: 50px 39px 49px 72px;
@@ -7764,7 +7774,7 @@ a:focus {
 		.solar-contents .article-detail .detail-left {
 			padding-right: 0;
 			padding-top: 85px;
-		}		
+		}
 		.solar-contents .article-detail .detail-left p {
 			margin-top: 10px;
 			padding-left: 5px;
@@ -7797,9 +7807,9 @@ a:focus {
 				padding-right: 36px;
 				margin-right: 0;
 			}
-				
-					
-	
+
+
+
 
 	/* blog page */
 	.titles.container .title-blog {
@@ -7809,7 +7819,7 @@ a:focus {
 		padding-left: 14px;
 		margin-top: -2px;
 	}
-	
+
 	/* .grid-data */
 	.grid-data.container {
 		padding: 0;
@@ -7975,8 +7985,8 @@ a:focus {
 							.grid-area.row .info-main .bottom-bar .btn-icon-gray .icons {
 								margin-top: 7px;
 							}
-		
-		
+
+
 		/* .loading-bar */
 		.loading-bar {
 			padding: 0 0 45px 0;
@@ -7988,7 +7998,7 @@ a:focus {
 				height: 22px;
 				display: block;
 				margin: 0 auto;
-			}	
+			}
 			/* .blog-details-data */
 			.blog-details-data.container {
 				padding: 0;
@@ -8059,8 +8069,8 @@ a:focus {
 						}
 						.blog-details-data.container .info-box .info-main .rights .down25 {
 							padding-bottom: 0;
-						}					
-					
+						}
+
 			/* .related-blog-module */
 			.related-blog-module {
 				padding: 26px 0 7px 0;
@@ -8142,7 +8152,7 @@ a:focus {
 					.related-blog-module .carousel-inner>.active {
 						min-height: 590px;
 					}
-				    
+
 			/* .comments-module */
 			.comments-module .container {
 				padding: 37px 38px 0 38px;
@@ -8273,9 +8283,9 @@ a:focus {
 							font-size: 14px;
 							padding: 2px 0 0 3px;
 						}
-	
-	
-	
+
+
+
 /* .footer */
 .footer .row {
 	padding: 0 23px 0 65px;
@@ -8392,7 +8402,7 @@ a:focus {
 .modal.modal-default .modal-dialog {
 	width: 706px;
 	margin: 209px auto;
-}	
+}
 	/* .modal-default .modal-header */
 	.modal.modal-default .btn-close {
 		background-position: -480px -88px;
@@ -8468,7 +8478,7 @@ a:focus {
 				display: none;
 			}
 }
-						
+
 
 
 
@@ -8541,8 +8551,8 @@ body {
 			width: 8px;
 			height: 8px;
 		}
-			.dropdown-default .btn-default.active .icon-arrow-down, 
-			.dropdown-default .btn-default:active .icon-arrow-down, 
+			.dropdown-default .btn-default.active .icon-arrow-down,
+			.dropdown-default .btn-default:active .icon-arrow-down,
 			.open.dropdown-default>.dropdown-toggle.btn-default .icon-arrow-down {
 				background-position: -56.5px 0;
 			}
@@ -8779,10 +8789,10 @@ body {
 						.tablet-circle {
 							display: none;
 						}
-						
-						
-						
-						
+
+
+
+
 					/* .active-projects-module .info-main */
 					.active-projects-module .info-main {
 						padding: 38px 29px 27px 30px;
@@ -8953,7 +8963,7 @@ body {
 							.how-it-works-module .carousel-indicators .active {
 								width: 9px;
 								height: 9px;
-							}	
+							}
 								.how-it-works-module .step-row .module-box {
 									padding: 5px 16px 0 16px;
 									min-height: 85px;
@@ -9079,12 +9089,12 @@ body {
 							background-size: 68.5px auto;
 							width: 68.5px;
 							height: 56.5px;
-						} 
+						}
 						.featured-on-module .logo-shareable {
 							background-size: 72px auto;
 							width: 72px;
 							height: 10.5px;
-						} 
+						}
 						.featured-on-module .logo-philanthropy {
 							background-size: 76.5px auto;
 							width: 76.5px;
@@ -9094,7 +9104,7 @@ body {
 							background-size: 76.5px auto;
 							width: 76.5px;
 							height: 22px;
-						} 
+						}
 			.featured-on-module .carousel-control.left,
 			.featured-on-module .carousel-control.right {
 				border: 1px solid #fff;
@@ -9126,8 +9136,8 @@ body {
 							.featured-on-module .carousel-control:hover.right .icons {
 								background-position: -192px -8px;
 							}
-			
-			
+
+
 
 	/* .newsletter-module */
 	.newsletter-module {
@@ -9185,7 +9195,7 @@ body {
 	.top150 {
 		margin-top: 92px;
 	}
-	
+
 	/* .titles */
 	.titles.container {
 		padding: 26px 0 0 0;
@@ -9201,9 +9211,9 @@ body {
 			font-size: 24px;
 			line-height: 30px;
 		}
-		
-			
-							
+
+
+
 	/* sign in page */
 	.contents.sign-in-contents {
 		min-height: 450px;
@@ -9228,12 +9238,12 @@ body {
 			float: none;
 			padding-top: 46px;
 		}
-			.sign-in .sign-in-left h2 {				
+			.sign-in .sign-in-left h2 {
 				font-size: 24px;
 				line-height: 26px;
-				margin-bottom: 7px;				
+				margin-bottom: 7px;
 			}
-			.sign-in .sign-in-left p {			
+			.sign-in .sign-in-left p {
 				font-size: 8px;
 				line-height: 16px;
 				padding-left: 0;
@@ -9243,7 +9253,7 @@ body {
 			}
 			.sign-in .sign-in-left .account p {
 				line-height: 10px;
-			} 
+			}
 			.sign-in .sign-in-left .account a {
 				font-size: 8px;
 				line-height: 10px;
@@ -9285,7 +9295,7 @@ body {
 	}
 	.sign-up {
 		padding: 26px 15px 12px 28px;
-	}	
+	}
 		.sign-up .title-blue-border {
 			border-width: 1px;
 		}
@@ -9301,21 +9311,21 @@ body {
 		.sign-up .sign-up-left {
 			float: none;
 			padding-top: 41px;
-			padding-left: 2px; 
+			padding-left: 2px;
 		}
-			.sign-up .sign-up-left h2 {				
+			.sign-up .sign-up-left h2 {
 				font-size: 24px;
 				line-height: 26px;
-				margin-bottom: 6px;				
+				margin-bottom: 6px;
 			}
-			.sign-up .sign-up-left p {			
+			.sign-up .sign-up-left p {
 				font-size: 8px;
 				line-height: 16px;
 				padding-left: 0;
 			}
 			.sign-up .sign-up-left .account {
 				margin-top: 16px;
-			}  
+			}
 			.sign-up .sign-up-left a {
 				font-size: 8px;
 				line-height: 16px;
@@ -9363,7 +9373,7 @@ body {
 					letter-spacing: 2px;
 				}
 
-	
+
 	/* what do page */
 	.contents.what-we-do-contents {
 		min-height: 500px;
@@ -9479,7 +9489,7 @@ body {
 			padding-left: 18px;
 			padding-right: 17px;
 			margin-left: 2px;
-		}		
+		}
 		/* .mains-tabs */
 		.mains-tabs .container {
 			width: 100%;
@@ -9501,10 +9511,10 @@ body {
 				border-width: 2px;
 			}
 			.mains-tabs .tab-index .row .col-lg-3 a:hover {
-				border-width: 2px; 
+				border-width: 2px;
 			}
 			.mains-tabs .tab-index .row .col-lg-3 a.active {
-				border-width: 2px; 
+				border-width: 2px;
 			}
 		.mains-tabs .tab-content {
 			min-height: 450px;
@@ -9521,7 +9531,7 @@ body {
 				margin-top: 23px;
 				width: 100%;
 				height: 248px;
-			}		
+			}
 			.mains-tabs .tab-content .content-right {
 				margin-left: 14px;
 			}
@@ -9548,7 +9558,7 @@ body {
 					}
 				.mains-tabs .tab-content .tab-funded .content-right  {
 					padding-top: 18px;
-				}					
+				}
 					.mains-tabs .tab-content .tab-funded .content-right p {
 						padding-right: 19px;
 						padding-top: 2px;
@@ -9570,11 +9580,11 @@ body {
 					.mains-tabs .tab-content .tab-involved .btn-blue:nth-child(2n) {
 						float: right;
 					}
-					
-	
+
+
 
 	/* get involved page */
-	
+
 		/* .info-area */
 		.info-area.container {
 			padding: 0 15px 18px 30px;
@@ -9588,7 +9598,7 @@ body {
 				padding-right: 35px;
 				padding-bottom: 8px;
 			}
-					
+
 		/* .list-area */
 		.list-area.container {
 			padding: 0 0 20px 0;
@@ -9688,7 +9698,7 @@ body {
 							.list-area .row .rights .bottom-bar .social-ul li {
 								margin-right: 9px;
 							}
-					
+
 		/* .past-projects-module */
 		  .past-projects-module .title-past-projects {
 			  letter-spacing: 5px;
@@ -9778,7 +9788,7 @@ body {
 											  .past-projects-module .carousel-control:hover.right .icons {
 												  background-position: -192px -8px;
 											  }
-	
+
 
 	/* project details page */
 	.details-active-project-module .banners.min-height455 {
@@ -9879,7 +9889,7 @@ body {
 							.details-active-project-module .txt-area .btn-icon-gray {
 								width: 35px;
 							}
-							
+
 							.details-active-project-module .txt-area .txt-td {
 								line-height: 10px;
 
@@ -9893,7 +9903,7 @@ body {
 									font-size: 8px;
 									line-height: 16px;
 								}
-				    
+
 			/* .project-updates-module */
 			.project-updates-module .container {
 				padding: 28px 16px 10px 16px;
@@ -9980,7 +9990,7 @@ body {
 												.project-updates-module .list-area .main-info .btn-icon-gray:hover .icon-gg {
 													background-position: -132px -8px;
 												}
-								 
+
 				/* .project-updates-module .right-aside */
 				.project-updates-module .right-aside {
 					margin-top: 19px;
@@ -10029,7 +10039,7 @@ body {
 							bottom: 12px;
 							left: 16px;
 						}
-				    
+
 			/* .donors-module */
 			.donors-module .titles.container {
 				min-height: 50px;
@@ -10074,14 +10084,14 @@ body {
 						line-height: 17px;
 						padding: 0 22px 0 0;
 					}
-					
 
-	/* solar ambassador program page */	
+
+	/* solar ambassador program page */
 	.contents.solar-ambassador-program-contents {
 		min-height: 800px;
 		margin-top: 91px;
 	}
-		/* .article-detail */	
+		/* .article-detail */
 		.solar-contents .article-detail {
 			padding: 26px 15px 12px 32px;
 		}
@@ -10104,7 +10114,7 @@ body {
 			}
 			.solar-contents .article-detail .detail-left .title-img {
 				margin-bottom: 11px;
-			}		
+			}
 			.solar-contents .article-detail .detail-left p {
 				margin-top: 5px;
 				padding-left: 3px;
@@ -10141,7 +10151,7 @@ body {
 					margin-right: 0;
 					clear: both;
 				}
-	
+
 
 	/* partners page */
 	.contents.partners-contents {
@@ -10164,7 +10174,7 @@ body {
 			margin-right: 15px;
 			margin-bottom: 20px;
 			letter-spacing: 3px;
-		} 
+		}
 		.partners-contents .titles .title-primary {
 			font-size: 24px;
 			line-height: 26px;
@@ -10215,7 +10225,7 @@ body {
 					line-height: 16px;
 					padding-right: 20px;
 					padding-left: 1px;
-				}			
+				}
 			.partners-contents .btn-wrap {
 				position: absolute;
 				left: -188px;
@@ -10227,7 +10237,7 @@ body {
 					padding-left: 24px;
 					padding-right: 25px;
 					letter-spacing: 2px;
-				}		
+				}
 			/* .partners-contents .pager-info */
 			.partners-contents .pager-info {
 				margin-top: -20px;
@@ -10244,8 +10254,8 @@ body {
 						font-size: 8px;
 						line-height: 20px;
 						height: 20px;
-					}	
-				    
+					}
+
 		/* .sponsoring-organizations-module */
 		.sponsoring-organizations-module {
 			min-height: 225px;
@@ -10319,9 +10329,9 @@ body {
 								.sponsoring-organizations-module .carousel-control:hover.right .icons {
 									background-position: -192px -8px;
 								}
-				
-					
-	
+
+
+
 
 	/* blog page */
 	.titles.container .title-blog {
@@ -10331,7 +10341,7 @@ body {
 		padding-left: 7px;
 		margin-top: -1px;
 	}
-	
+
 	/* .grid-data */
 	.grid-data.container {
 		padding: 0;
@@ -10478,8 +10488,8 @@ body {
 							.grid-area.row .info-main .bottom-bar .btn-icon-gray .icons {
 								margin-top: 3.5px;
 							}
-		
-		
+
+
 		/* .loading-bar */
 		.loading-bar {
 			padding: 0 0 9px 0;
@@ -10489,7 +10499,7 @@ body {
 				background-size: 64px auto;
 				width: 64px;
 				height: 21px;
-			}	
+			}
 			/* .blog-details-data */
 			.blog-details-data.container {
 				min-height: 150px;
@@ -10541,8 +10551,8 @@ body {
 						.blog-details-data.container .info-box .info-main .lefts .font14,
 						.blog-details-data.container .info-box .down25 {
 							padding-bottom: 17px;
-						}			
-					
+						}
+
 			/* .related-blog-module */
 			.related-blog-module {
 				padding: 13px 0 3px 0;
@@ -10606,7 +10616,7 @@ body {
 					.related-blog-module .carousel-inner>.active {
 						min-height: 295px;
 					}
-				    
+
 			/* .comments-module */
 			.comments-module .container {
 				padding: 18px 19px 0 19px;
@@ -10737,10 +10747,10 @@ body {
 							padding: 1px 0 0 1.5px;
 
 						}
-	
-	
-	
-	
+
+
+
+
 /* .footer */
 .footer .row {
 	padding: 0 21.5px 0 32.5px;
@@ -10831,7 +10841,7 @@ body {
 .modal.modal-default .modal-dialog {
 	width: 346px;
 	margin: 102px auto;
-}	
+}
 	/* .modal-default .modal-header */
 	.modal.modal-default .btn-close {
 		background-position: -240px -44px;
@@ -10896,11 +10906,11 @@ body {
 						}
 }
 
-	
-	
-	
-/* iPads (min-width : 992px) and (max-width : 1024px) */	
-@media (min-width : 992px) and (max-width : 1024px) and (-webkit-min-device-pixel-ratio : 1.5){ 
+
+
+
+/* iPads (min-width : 992px) and (max-width : 1024px) */
+@media (min-width : 992px) and (max-width : 1024px) and (-webkit-min-device-pixel-ratio : 1.5){
 	.header .logo,
 	.footer .bottoms .logo {
 		background: url(../images/logo-white@2x.png) no-repeat;
@@ -10928,11 +10938,11 @@ body {
 	}
 }
 
-	
-	
-	
-/* iPads (min-width : 768px) and (max-width : 991px) */	
-@media (min-width : 768px) and (max-width : 991px) and (-webkit-min-device-pixel-ratio : 1.5){ 
+
+
+
+/* iPads (min-width : 768px) and (max-width : 991px) */
+@media (min-width : 768px) and (max-width : 991px) and (-webkit-min-device-pixel-ratio : 1.5){
 	.header .logo,
 	.footer .bottoms .logo {
 		background: url(../images/tablet/tablet-logo-white@2x.png);
@@ -10966,11 +10976,11 @@ body {
 	}
 }
 
-	
-	
-	
-/* iPhone (min-width : 375px) and (max-width : 767px) */	
-@media (min-width : 375px) and (max-width : 767px) and (-webkit-min-device-pixel-ratio : 1.5){ 
+
+
+
+/* iPhone (min-width : 375px) and (max-width : 767px) */
+@media (min-width : 375px) and (max-width : 767px) and (-webkit-min-device-pixel-ratio : 1.5){
 	.header .logo,
 	.footer .bottoms .logo {
 		background: url(../images/mobile/mobile-logo-white@2x.png);
@@ -11017,7 +11027,7 @@ body {
 
 .payment-modal-content .modal-header {
     font-weight: bold;
-    font-size: 18px; 
+    font-size: 18px;
 }
 
 label.checkmark {

--- a/revolv/templates/revolv_cms/blocks/image_block.html
+++ b/revolv/templates/revolv_cms/blocks/image_block.html
@@ -8,4 +8,8 @@
     {% image self.image max-800x600 class=self.layout %}
 {% elif self.size == 'large' %}
     {% image self.image max-1280x768 class=self.layout %}
+{% elif self.size == 'full_width' %}
+    {% with class_val=self.layout|add:" full-width" %}
+        {% image self.image max-1280x768 class=class_val %}
+    {% endwith %}
 {% endif %}

--- a/revolv/templates/revolv_cms/blocks/image_block.html
+++ b/revolv/templates/revolv_cms/blocks/image_block.html
@@ -1,0 +1,11 @@
+{% load wagtailimages_tags %}
+
+{% if self.size == 'tiny' %}
+    {% image self.image max-100x100 class=self.layout %}
+{% elif self.size == 'small' %}
+    {% image self.image max-300x200 class=self.layout %}
+{% elif self.size == 'medium' %}
+    {% image self.image max-800x600 class=self.layout %}
+{% elif self.size == 'large' %}
+    {% image self.image max-1280x768 class=self.layout %}
+{% endif %}

--- a/revolv/templates/revolv_cms/blocks/rich_list.html
+++ b/revolv/templates/revolv_cms/blocks/rich_list.html
@@ -1,0 +1,7 @@
+<ul>
+    {% for block in self.list_content %}
+      <li class="{{ block.display_type }} {{ block.main_axis }} {{ block.perpendicular_axis }}">
+        {{ block.content }}
+      </li>
+    {% endfor %}
+</ul>

--- a/revolv/templates/revolv_cms/revolv_custom_page.html
+++ b/revolv/templates/revolv_cms/revolv_custom_page.html
@@ -7,10 +7,12 @@
 {% endblock head %}
 
 {% block body %}
-<div class="cms-content-row row">
-    <div class="small-12 columns">
-        <h1>{{ self.title }}</h1>
-        {{ self.body|richtext }}
+    <div class="cms-content-container container">
+        <div class="cms-content-row row">
+            <div class="col-sm-12">
+                <h1>{{ self.title }}</h1>
+                {{ self.body|richtext }}
+            </div>
+        </div>
     </div>
-</div>
 {% endblock body %}

--- a/revolv/templates/revolv_cms/revolv_custom_page.html
+++ b/revolv/templates/revolv_cms/revolv_custom_page.html
@@ -11,7 +11,9 @@
         <div class="cms-content-row row">
             <div class="col-sm-12">
                 <h1>{{ self.title }}</h1>
-                {{ self.body|richtext }}
+                {% for block in self.body %}
+                    {{ block }}
+                {% endfor %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
This adds numerous improvements to the layout and style of "REvolv custom pages", which are the generic CMS content pages for the REvolv site.

Generic improvements:
- On content pages, the footer is made sticky.
- The margin at the top of the main content well on content pages is made screen-width-sensitive to accommodate the changes in the height of the header on different widths.
- Some padding is added to improve appearance.

The more substantial improvement comes about from replacing the content page's simple RichTextField-based content with a more sophisticated StreamField that opens up a number of possibilities. The StreamField is a means of editing page content as a series of "blocks". It is documented fully [here](http://docs.wagtail.io/en/v1.3.1/topics/streamfield.html).

This pull request makes the following StreamField-related additions to the models and templates:
- The RevolvCustomPage model's `body` attribute is turned into a StreamField that accepts three block types: rich text, an ImageBlock (see blow), and a RichListBlock (see below).
- A custom ImageBlock block. This block includes an image; a "size" parameter (allowing the user to choose an Extra Small, Small, etc image); and a "layout" parameter (allowing the user to float the image left and right or make it inline or whatever).
- A custom RichListBlock block. This is a ListBlock where each list item is, basically, a StreamBlock that can contain arbitrarily many ImageBlocks or RichTextBlocks. But that StreamBlock also accepts parameters that define the display type and let the user set `align-items` and `justify-content` values. The upshot of this is that the user can create a row of items that are vertically centered by selecting the `Row` display type; the `Start` main axis value; and the `Center` perpendicular axis value.

A good way to test this would be to recreate the [Solar Ambassadors page](http://re-volv.org/content/solar-ambassadors-0) from the production site. To do this, first run the `grunt sass` build step to build the site CSS. Then:
1. Go to `/cms/`. Go to the _Explorer_ area. Choose a parent page. Press the **Add Child Page** button to create a page. Select **Revolv Custom Page** as the page type.
2. Give the page a title.
3. Under _Body_, you should see a greyed in area offering you three choices, like so: 
   ![image](https://cloud.githubusercontent.com/assets/1625749/12825753/d05c821c-cb45-11e5-8c23-9781e2f6026f.png) — choose **Rich Text**. Enter in some text (to emulate the appearance of the lead-in text at the top of the production Solar Ambassadors page).
4. Underneath your newly added rich text section, there will be a grey plus sign. Click this; it will display the same grey selection panel as before. Click **Rich List**.
5. You will see the edit panel for a Rich List and its items: 
   ![image](https://cloud.githubusercontent.com/assets/1625749/12825816/0ecb52d0-cb46-11e5-925d-f2fcad7b788d.png) — select Display Type _Row_ and Perpendicular Axis _Center_.
6. Use the grey panel beneath the select inputs to add an Image. Upload an image using the file picker. Select the size _Small_. Select the Layout type _Block_.
7. Use the grey plus sign to open up the grey panel and add a Rich Text field. Enter in some text (to emulate the text next to photos on the Solar Ambassador prod page).
8. Press **Add Another** to add another row. Repeat steps 5-7 to create as many "solar ambassadors" as you want.
9. At the bottom of the page, where it says **Save as Draft**, use the select arrow to choose **Publish** and publish the page. You can then view it live and verify that it has worked. (Styles will not work properly until you publish.)
